### PR TITLE
Users table, BCrypt, JWT issuance, POST /api/v1/auth/login

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,6 +14,7 @@
 
 	<properties>
 		<java.version>25</java.version>
+        <jjwt.version>0.13.0</jjwt.version>
 	</properties>
 	<dependencies>
         <dependency>
@@ -43,6 +44,26 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+
+        <!-- JWT -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/config/SecurityConfig.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -29,14 +32,22 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .cors(c -> c.configurationSource(corsConfigurationSource()))
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()); // TODO(E2): lock down to JWT
+                .requestMatchers("/api/auth/**", "/actuator/health").permitAll()
+                .anyRequest().permitAll());
+                // TODO(#29): replace permitAll with authenticated() + JwtAuthenticationFilter / resource server
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/User.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/User.java
@@ -1,0 +1,51 @@
+package com.ubb.deliveryhub.identity.domain;
+
+import com.ubb.deliveryhub.identity.domain.embedded.UserRole;
+import com.ubb.deliveryhub.identity.domain.id.UserId;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = UserId.TABLE_NAME,
+    indexes = {
+        @Index(name = "users_email_idx", columnList = "email", unique = true)
+    }
+)
+@Data
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(name = UserId.EMAIL, nullable = false)
+    private String email;
+
+    @Column(name = UserId.PASSWORD_HASH, nullable = false)
+    private String passwordHash;
+
+    @Column(name = UserId.ROLE, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Column(name = UserId.CREATED_AT,  nullable = false)
+    private Instant createdAt;
+
+    @Column(name = UserId.UPDATED_AT,  nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    private void onCreate() {
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/dto/LoginRequestDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/dto/LoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.ubb.deliveryhub.identity.domain.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    private String email;
+    private String password;
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/dto/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package com.ubb.deliveryhub.identity.domain.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginResponseDto {
+
+    private String token;
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/embedded/UserRole.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/embedded/UserRole.java
@@ -1,0 +1,7 @@
+package com.ubb.deliveryhub.identity.domain.embedded;
+
+public enum UserRole {
+    CUSTOMER,
+    COURIER,
+    ADMIN
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/exception/AuthException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.ubb.deliveryhub.identity.domain.exception;
+
+import java.io.Serial;
+
+public class AuthException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 8138174567182170609L;
+
+    public AuthException(String message) {
+        super(message);
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.ubb.deliveryhub.identity.domain.exception;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Log4j2
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ProblemDetail> handleAuthException(AuthException ex) {
+        log.error("AuthException", ex);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).
+            body(ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, ex.getMessage()));
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/domain/id/UserId.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/domain/id/UserId.java
@@ -1,0 +1,16 @@
+package com.ubb.deliveryhub.identity.domain.id;
+
+public class UserId {
+
+    public static final String TABLE_NAME = "users";
+    public static final String EMAIL = "email";
+    public static final String PASSWORD_HASH = "password_hash";
+    public static final String ROLE = "role";
+    public static final String CREATED_AT = "created_at";
+    public static final String UPDATED_AT = "updated_at";
+
+    private UserId() {
+        throw new IllegalStateException("Constants only class");
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/repository/UserRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.ubb.deliveryhub.identity.repository;
+
+import com.ubb.deliveryhub.identity.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+
+    Optional<User> findByEmail(String email);
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/service/AuthService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/service/AuthService.java
@@ -1,0 +1,32 @@
+package com.ubb.deliveryhub.identity.service;
+
+import com.ubb.deliveryhub.identity.domain.dto.LoginRequestDto;
+import com.ubb.deliveryhub.identity.domain.dto.LoginResponseDto;
+import com.ubb.deliveryhub.identity.domain.exception.AuthException;
+import com.ubb.deliveryhub.identity.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository repository;
+    private final PasswordEncoder encoder;
+    private final JwtService jwtService;
+
+    public LoginResponseDto login(LoginRequestDto  loginRequestDto) {
+        var user =  repository.findByEmail(loginRequestDto.getEmail())
+            .orElse(null);
+
+        if (user == null || !encoder.matches(loginRequestDto.getPassword(), user.getPasswordHash())) {
+            throw new AuthException("Invalid credentials");
+        }
+
+        return LoginResponseDto.builder()
+            .token(jwtService.generateToken(user))
+            .build();
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/service/JwtService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/service/JwtService.java
@@ -26,7 +26,7 @@ public class JwtService {
             .subject(user.getId())
             .claim("role", user.getRole())
             .issuedAt(Date.from(now))
-            .expiration(Date.from(now.plusSeconds(expiration)))
+            .expiration(Date.from(now.plusMillis(expiration)))
             .signWith(getSecretKey(), Jwts.SIG.HS256)
             .compact();
     }

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/service/JwtService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/service/JwtService.java
@@ -1,0 +1,38 @@
+package com.ubb.deliveryhub.identity.service;
+
+import com.ubb.deliveryhub.identity.domain.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private Long expiration;
+
+    public String generateToken(User user) {
+        var now = Instant.now();
+        return Jwts.builder()
+            .subject(user.getId())
+            .claim("role", user.getRole())
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plusSeconds(expiration)))
+            .signWith(getSecretKey(), Jwts.SIG.HS256)
+            .compact();
+    }
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/identity/web/AuthController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/identity/web/AuthController.java
@@ -1,0 +1,25 @@
+package com.ubb.deliveryhub.identity.web;
+
+import com.ubb.deliveryhub.identity.domain.dto.LoginRequestDto;
+import com.ubb.deliveryhub.identity.domain.dto.LoginResponseDto;
+import com.ubb.deliveryhub.identity.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService service;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> loginUser(@RequestBody LoginRequestDto loginRequestDto) {
+        return ResponseEntity.ok(service.login(loginRequestDto));
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.jpa.properties.hibernate.format_sql=true
 # Flyway Configuration
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+# JWT Configuration
+jwt.secret=36cd8c7dd84ace459ec4e262e4aa96cd
+jwt.expiration=86400000

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -2,7 +2,9 @@
 
 CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
-    password_hash VARCHAR(255) NOT NULL
+    password_hash VARCHAR(60) NOT NULL,
+    role VARCHAR(32) NOT NULL CHECK (role IN ('CUSTOMER', 'COURIER', 'ADMIN')),
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
 );

--- a/backend/src/main/resources/db/migration/V2__seed_dev_users.sql
+++ b/backend/src/main/resources/db/migration/V2__seed_dev_users.sql
@@ -1,0 +1,29 @@
+-- V2__seed_dev_users.sql
+-- Dev-only test users (task #25). README: password = "password" for all.
+
+DELETE FROM users WHERE email IN (
+                                  'customer@deliveryhub.local',
+                                  'courier@deliveryhub.local',
+                                  'admin@deliveryhub.local'
+    );
+
+INSERT INTO users (id, email, password_hash, role, created_at, updated_at)
+VALUES
+    ('a0000001-0000-4000-8000-000000000001'::uuid,
+     'customer@deliveryhub.local',
+     '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG',
+     'CUSTOMER',
+     now(),
+     now()),
+    ('a0000002-0000-4000-8000-000000000002'::uuid,
+     'courier@deliveryhub.local',
+     '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG',
+     'COURIER',
+     now(),
+     now()),
+    ('a0000003-0000-4000-8000-000000000003'::uuid,
+     'admin@deliveryhub.local',
+     '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG',
+     'ADMIN',
+     now(),
+     now());


### PR DESCRIPTION
This pull request introduces a foundational authentication system using JWT (JSON Web Tokens) for the backend, including user entity modeling, secure password handling, and initial database seeding for development. The changes cover database schema updates, new authentication endpoints, JWT token generation, and exception handling to support secure login functionality.

**Authentication & Security Infrastructure:**

* Added JWT dependencies to `pom.xml` and configured JWT secret and expiration in `application.properties`, enabling token-based authentication. 
* Implemented `SecurityConfig` to enforce stateless session management, configure CORS, and provide a `PasswordEncoder` bean for secure password hashing. 

**User Domain & Persistence:**

* Created the `User` entity, `UserRole` enum, and supporting classes for user persistence and role management, including a JPA repository for user queries.
* Updated the initial database migration to match the new user model, including roles and timestamp fields, and added a migration to seed development users with hashed passwords. 

**Authentication Logic & API:**

* Added DTOs for login requests and responses, and implemented `AuthService` to handle user authentication, password verification, and JWT token issuance. 
* Introduced `AuthController` with a `/api/auth/login` endpoint for user authentication, returning a JWT token upon successful login.

**Error Handling:**

* Implemented custom `AuthException` and a global exception handler to return proper HTTP error responses for authentication failures. 