### PR TITLE
GET /api/v1/deliveries (customer scoped) + pagination (#33)

### DIFF
--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/DeliveryListDefaults.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/DeliveryListDefaults.java
@@ -1,0 +1,14 @@
+package com.ubb.deliveryhub.delivery;
+
+/**
+ * Defaults for {@code GET /deliveries}; keep {@link #PAGE_SIZE} aligned with
+ * {@code spring.data.web.pageable.default-page-size} in {@code application.properties}.
+ */
+public final class DeliveryListDefaults {
+
+    public static final int PAGE_SIZE = 20;
+    public static final String SORT_PROPERTY = "createdAt";
+
+    private DeliveryListDefaults() {
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliverySummaryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliverySummaryDto.java
@@ -1,0 +1,23 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Row shape for customer delivery lists (#33 / Angular #35); camelCase for JSON.
+ */
+@Value
+@Builder
+public class DeliverySummaryDto {
+    String id;
+    String status;
+    String deliveryType;
+    Instant createdAt;
+    BigDecimal totalAmount;
+    String currency;
+    String pickupCity;
+    String destinationCity;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliveryPaginationException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliveryPaginationException.java
@@ -1,0 +1,17 @@
+package com.ubb.deliveryhub.delivery.domain.exception;
+
+import java.io.Serial;
+
+/**
+ * Raised when the client requests an unpaged result (e.g. {@code unpaged=true}), which would load
+ * an unbounded row set.
+ */
+public class InvalidDeliveryPaginationException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public InvalidDeliveryPaginationException() {
+        super("Paged query parameters are required (page and size). Unpaged listings are not supported.");
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliverySortException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliverySortException.java
@@ -1,13 +1,40 @@
 package com.ubb.deliveryhub.delivery.domain.exception;
 
 import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 public class InvalidDeliverySortException extends RuntimeException {
 
     @Serial
     private static final long serialVersionUID = 1L;
 
-    public InvalidDeliverySortException(String message) {
-        super(message);
+    private final String invalidProperty;
+    private final List<String> allowedProperties;
+
+    public InvalidDeliverySortException(String invalidProperty, Collection<String> allowedProperties) {
+        super(buildDetail(invalidProperty, allowedProperties));
+        this.invalidProperty = invalidProperty;
+        this.allowedProperties = sortedCopy(allowedProperties);
+    }
+
+    public String getInvalidProperty() {
+        return invalidProperty;
+    }
+
+    public List<String> getAllowedProperties() {
+        return allowedProperties;
+    }
+
+    private static String buildDetail(String invalidProperty, Collection<String> allowedProperties) {
+        return "Invalid sort property: %s. Allowed: %s".formatted(invalidProperty, String.join(", ", sortedCopy(allowedProperties)));
+    }
+
+    private static List<String> sortedCopy(Collection<String> allowedProperties) {
+        List<String> copy = new ArrayList<>(allowedProperties);
+        copy.sort(Comparator.naturalOrder());
+        return List.copyOf(copy);
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliverySortException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliverySortException.java
@@ -1,0 +1,13 @@
+package com.ubb.deliveryhub.delivery.domain.exception;
+
+import java.io.Serial;
+
+public class InvalidDeliverySortException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public InvalidDeliverySortException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -1,19 +1,16 @@
 package com.ubb.deliveryhub.delivery.repository;
 
 import com.ubb.deliveryhub.delivery.domain.Delivery;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
-
-    Page<Delivery> findByCustomer_Id(UUID customerId, Pageable pageable);
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSpecificationExecutor<Delivery> {
 
     boolean existsByCustomer_IdAndId(UUID customerId, UUID id);
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliverySpecifications.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliverySpecifications.java
@@ -2,6 +2,9 @@ package com.ubb.deliveryhub.delivery.repository;
 
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.identity.domain.User;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.UUID;
@@ -13,10 +16,12 @@ public final class DeliverySpecifications {
 
     /**
      * Scope to one customer; optional exact status (dashboard / history filters).
+     * Explicit inner join on customer matches {@code (customer_id, status)} index usage.
      */
     public static Specification<Delivery> forCustomerWithOptionalStatus(UUID customerId, DeliveryStatus status) {
         return (root, query, cb) -> {
-            var byCustomer = cb.equal(root.get("customer").get("id"), customerId);
+            Join<Delivery, User> customerJoin = root.join("customer", JoinType.INNER);
+            var byCustomer = cb.equal(customerJoin.get("id"), customerId);
             if (status == null) {
                 return byCustomer;
             }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliverySpecifications.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliverySpecifications.java
@@ -1,0 +1,26 @@
+package com.ubb.deliveryhub.delivery.repository;
+
+import com.ubb.deliveryhub.delivery.domain.Delivery;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.UUID;
+
+public final class DeliverySpecifications {
+
+    private DeliverySpecifications() {
+    }
+
+    /**
+     * Scope to one customer; optional exact status (dashboard / history filters).
+     */
+    public static Specification<Delivery> forCustomerWithOptionalStatus(UUID customerId, DeliveryStatus status) {
+        return (root, query, cb) -> {
+            var byCustomer = cb.equal(root.get("customer").get("id"), customerId);
+            if (status == null) {
+                return byCustomer;
+            }
+            return cb.and(byCustomer, cb.equal(root.get("status"), status));
+        };
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -9,6 +9,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.CourierSummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.PackageRequestDto;
 import com.ubb.deliveryhub.delivery.domain.dto.TimelineEntryDto;
 import com.ubb.deliveryhub.delivery.domain.embedded.AddressContact;
@@ -66,6 +67,21 @@ public final class DeliveryMapper {
         a.setContactName(dto.getContactName());
         a.setContactPhone(dto.getContactPhone());
         return a;
+    }
+
+    public static DeliverySummaryDto toSummaryDto(Delivery d) {
+        String pickupCity = d.getPickup() != null ? d.getPickup().getCity() : null;
+        String destinationCity = d.getDestination() != null ? d.getDestination().getCity() : null;
+        return DeliverySummaryDto.builder()
+            .id(d.getId().toString())
+            .status(d.getStatus().name())
+            .deliveryType(d.getDeliveryType().name())
+            .createdAt(d.getCreatedAt())
+            .totalAmount(d.getTotalAmount())
+            .currency(d.getCurrency())
+            .pickupCity(pickupCity)
+            .destinationCity(destinationCity)
+            .build();
     }
 
     public static DeliveryDto toDto(Delivery d) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -1,5 +1,6 @@
 package com.ubb.deliveryhub.delivery.service;
 
+import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
@@ -9,6 +10,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryNotFoundException;
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
 import com.ubb.deliveryhub.delivery.repository.DeliverySpecifications;
@@ -28,10 +30,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
-import java.util.Comparator;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,10 +46,6 @@ public class DeliveryService {
         "trackingCode"
     );
 
-    private static final String SORT_ALLOWED_LIST = ALLOWED_DELIVERY_LIST_SORT_PROPERTIES.stream()
-        .sorted(Comparator.naturalOrder())
-        .collect(Collectors.joining(", "));
-
     private static final String TRACKING_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final int TRACKING_BODY_LEN = 10;
     private static final int TRACKING_CODE_SAVE_ATTEMPTS = 15;
@@ -63,7 +59,7 @@ public class DeliveryService {
 
     @Transactional
     public DeliveryDto createFromPrincipal(Authentication authentication, CreateDeliveryRequest request) {
-        UUID customerId = UUID.fromString(authentication.getName());
+        UUID customerId = principalUserId(authentication);
         User customer = userRepository.findById(customerId)
             .orElseThrow(() -> new EntityNotFoundException("User with id %s not found".formatted(customerId)));
 
@@ -105,11 +101,18 @@ public class DeliveryService {
         Pageable pageable,
         DeliveryStatus statusFilter
     ) {
+        if (!pageable.isPaged()) {
+            throw new InvalidDeliveryPaginationException();
+        }
         assertAllowedSort(pageable.getSort());
         Pageable effective = applyDefaultSort(pageable);
-        UUID customerId = UUID.fromString(authentication.getName());
+        UUID customerId = principalUserId(authentication);
         Specification<Delivery> spec = DeliverySpecifications.forCustomerWithOptionalStatus(customerId, statusFilter);
         return deliveryRepository.findAll(spec, effective).map(DeliveryMapper::toSummaryDto);
+    }
+
+    private static UUID principalUserId(Authentication authentication) {
+        return UUID.fromString(authentication.getName());
     }
 
     private static void assertAllowedSort(Sort sort) {
@@ -118,9 +121,7 @@ public class DeliveryService {
         }
         for (Sort.Order order : sort) {
             if (!ALLOWED_DELIVERY_LIST_SORT_PROPERTIES.contains(order.getProperty())) {
-                throw new InvalidDeliverySortException(
-                    "Invalid sort property: %s. Allowed: %s".formatted(order.getProperty(), SORT_ALLOWED_LIST)
-                );
+                throw new InvalidDeliverySortException(order.getProperty(), ALLOWED_DELIVERY_LIST_SORT_PROPERTIES);
             }
         }
     }
@@ -132,7 +133,7 @@ public class DeliveryService {
         return PageRequest.of(
             pageable.getPageNumber(),
             pageable.getPageSize(),
-            Sort.by(Sort.Direction.DESC, "createdAt")
+            Sort.by(Sort.Direction.DESC, DeliveryListDefaults.SORT_PROPERTY)
         );
     }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -7,24 +7,48 @@ import com.ubb.deliveryhub.delivery.domain.MoneySnapshot;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryNotFoundException;
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
+import com.ubb.deliveryhub.delivery.repository.DeliverySpecifications;
 import com.ubb.deliveryhub.delivery.repository.DeliveryStatusHistoryRepository;
 import com.ubb.deliveryhub.identity.domain.User;
 import com.ubb.deliveryhub.identity.domain.exception.EntityNotFoundException;
 import com.ubb.deliveryhub.identity.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.util.Comparator;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class DeliveryService {
+
+    private static final Set<String> ALLOWED_DELIVERY_LIST_SORT_PROPERTIES = Set.of(
+        "createdAt",
+        "updatedAt",
+        "status",
+        "deliveryType",
+        "totalAmount",
+        "trackingCode"
+    );
+
+    private static final String SORT_ALLOWED_LIST = ALLOWED_DELIVERY_LIST_SORT_PROPERTIES.stream()
+        .sorted(Comparator.naturalOrder())
+        .collect(Collectors.joining(", "));
 
     private static final String TRACKING_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final int TRACKING_BODY_LEN = 10;
@@ -73,6 +97,43 @@ public class DeliveryService {
         deliveryAuthorization.assertCanView(delivery, authentication);
         var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(id);
         return DeliveryMapper.toDetailDto(delivery, history);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DeliverySummaryDto> listForCurrentCustomer(
+        Authentication authentication,
+        Pageable pageable,
+        DeliveryStatus statusFilter
+    ) {
+        assertAllowedSort(pageable.getSort());
+        Pageable effective = applyDefaultSort(pageable);
+        UUID customerId = UUID.fromString(authentication.getName());
+        Specification<Delivery> spec = DeliverySpecifications.forCustomerWithOptionalStatus(customerId, statusFilter);
+        return deliveryRepository.findAll(spec, effective).map(DeliveryMapper::toSummaryDto);
+    }
+
+    private static void assertAllowedSort(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return;
+        }
+        for (Sort.Order order : sort) {
+            if (!ALLOWED_DELIVERY_LIST_SORT_PROPERTIES.contains(order.getProperty())) {
+                throw new InvalidDeliverySortException(
+                    "Invalid sort property: %s. Allowed: %s".formatted(order.getProperty(), SORT_ALLOWED_LIST)
+                );
+            }
+        }
+    }
+
+    private static Pageable applyDefaultSort(Pageable pageable) {
+        if (!pageable.getSort().isUnsorted()) {
+            return pageable;
+        }
+        return PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            Sort.by(Sort.Direction.DESC, "createdAt")
+        );
     }
 
     private String randomAlphanumeric(int len) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -1,11 +1,17 @@
 package com.ubb.deliveryhub.delivery.web;
 
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.service.DeliveryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -14,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -26,6 +33,16 @@ import java.util.UUID;
 public class DeliveryController {
 
     private final DeliveryService deliveryService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public Page<DeliverySummaryDto> listForCurrentCustomer(
+        Authentication authentication,
+        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+        @RequestParam(required = false) DeliveryStatus status
+    ) {
+        return deliveryService.listForCurrentCustomer(authentication, pageable, status);
+    }
 
     @PostMapping
     @PreAuthorize("hasRole('CUSTOMER')")

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -1,5 +1,6 @@
 package com.ubb.deliveryhub.delivery.web;
 
+import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
@@ -38,7 +39,11 @@ public class DeliveryController {
     @PreAuthorize("hasRole('CUSTOMER')")
     public Page<DeliverySummaryDto> listForCurrentCustomer(
         Authentication authentication,
-        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+        @PageableDefault(
+            size = DeliveryListDefaults.PAGE_SIZE,
+            sort = DeliveryListDefaults.SORT_PROPERTY,
+            direction = Sort.Direction.DESC
+        ) Pageable pageable,
         @RequestParam(required = false) DeliveryStatus status
     ) {
         return deliveryService.listForCurrentCustomer(authentication, pageable, status);

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.ubb.deliveryhub.delivery.web;
+
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class DeliveryExceptionHandler {
+
+    @ExceptionHandler(InvalidDeliverySortException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidDeliverySort(InvalidDeliverySortException ex) {
+        return ResponseEntity.badRequest()
+            .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.ubb.deliveryhub.delivery.web;
 
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -12,6 +13,14 @@ public class DeliveryExceptionHandler {
 
     @ExceptionHandler(InvalidDeliverySortException.class)
     public ResponseEntity<ProblemDetail> handleInvalidDeliverySort(InvalidDeliverySortException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setProperty("invalidSortProperty", ex.getInvalidProperty());
+        pd.setProperty("allowedSortProperties", ex.getAllowedProperties());
+        return ResponseEntity.badRequest().body(pd);
+    }
+
+    @ExceptionHandler(InvalidDeliveryPaginationException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidDeliveryPagination(InvalidDeliveryPaginationException ex) {
         return ResponseEntity.badRequest()
             .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage()));
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,6 +6,10 @@ management.endpoints.web.exposure.include=health,info
 
 spring.profiles.default=local
 
+# Pagination for GET /deliveries (customer list, #33)
+spring.data.web.pageable.default-page-size=20
+spring.data.web.pageable.max-page-size=100
+
 # JPA and Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,7 +6,7 @@ management.endpoints.web.exposure.include=health,info
 
 spring.profiles.default=local
 
-# Pagination for GET /deliveries (customer list, #33)
+# default-page-size must match com.ubb.deliveryhub.delivery.DeliveryListDefaults.PAGE_SIZE
 spring.data.web.pageable.default-page-size=20
 spring.data.web.pageable.max-page-size=100
 


### PR DESCRIPTION
This pull request introduces a new paginated and filterable endpoint for customers to list their deliveries, along with supporting backend infrastructure. It adds a summary DTO, repository specifications, sorting validation, and a controller method to expose the new list API. Error handling for invalid sort properties is also included.

**Customer Delivery List API**

* Added a new endpoint `GET /deliveries` for customers to retrieve a paginated, optionally status-filtered list of their deliveries, returning `DeliverySummaryDto` objects. Sorting is allowed only on specific fields, and defaults to `createdAt` descending. 
**DTOs and Mapping**

* Introduced `DeliverySummaryDto` to represent summary rows for delivery lists, and implemented a mapper method to convert `Delivery` entities to this DTO. 

**Repository and Query Enhancements**

* Updated `DeliveryRepository` to support JPA specifications and added `DeliverySpecifications` for filtering deliveries by customer and status. 

**Sorting and Validation**

* Implemented validation to restrict allowed sort properties for the list endpoint, throwing `InvalidDeliverySortException` for invalid sorts. Default sorting is applied if none is provided. 

**Error Handling**

* Added `DeliveryExceptionHandler` to return a proper HTTP 400 response with details when an invalid sort property is requested.