### PR TITLE
Customer: Create Delivery page + DeliveryService (#34)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -118,8 +118,16 @@ Expected JSON includes `"status":"UP"`.
 
 JWT Bearer authentication is enforced for routes outside `/auth/**` and `/actuator/health`. Tokens are issued at login (`POST /api/auth/login`) and carry `sub` (user id) plus a `role` claim so `@PreAuthorize` can distinguish roles.
 
-## Delivery pricing (POST `/api/deliveries`)
+## Delivery create payload (POST `/api/deliveries`)
 
-Pricing is computed only on the server (`PricingService`) and persisted as `base_amount`, `fee_amount`, `tax_amount`, `total_amount`, `currency` on `deliveries`. MVP rules are summarized in the Javadoc on `com.ubb.deliveryhub.delivery.service.PricingService` (tiered STANDARD transport by weight, EXPRESS surcharge + rush fee, fragile handling fee, 19% VAT on taxable amount).
+The create endpoint accepts the simplified frontend request shape:
+
+- `pickup`: `line1`, `contactName`, `contactPhone`
+- `destination`: `line1`, `contactName`, `contactPhone`
+- `package`: `weightKg`, `description`
+- `deliveryType`, `specialInstructions`
+- `pricing`: `baseAmount`, `feeAmount`, `taxAmount`, `totalAmount`, `currency`
+
+Pricing ownership is client-side for this flow: backend validates the pricing snapshot and persists it directly to `deliveries` (`base_amount`, `fee_amount`, `tax_amount`, `total_amount`, `currency`) without server-side recalculation.
 
 **Idempotency:** duplicate POSTs create separate deliveries (GitHub #31).

--- a/backend/README.md
+++ b/backend/README.md
@@ -130,4 +130,11 @@ The create endpoint accepts the simplified frontend request shape:
 
 Pricing ownership is client-side for this flow: backend validates the pricing snapshot and persists it directly to `deliveries` (`base_amount`, `fee_amount`, `tax_amount`, `total_amount`, `currency`) without server-side recalculation.
 
+## Delivery list payload (GET `/api/deliveries`)
+
+List rows include route-friendly address fields in camelCase:
+
+- `destinationLine1` (main route text)
+- `pickupLine1` (route hint, e.g. "from ...")
+
 **Idempotency:** duplicate POSTs create separate deliveries (GitHub #31).

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
@@ -60,11 +60,6 @@ public class Delivery {
     @Embedded
     @AttributeOverrides({
         @AttributeOverride(name = AddressContactId.Property.LINE1, column = @Column(name = DeliveryId.PICKUP_LINE1, nullable = false)),
-        @AttributeOverride(name = AddressContactId.Property.LINE2, column = @Column(name = DeliveryId.PICKUP_LINE2)),
-        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.PICKUP_CITY, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.REGION, column = @Column(name = DeliveryId.PICKUP_REGION, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.PICKUP_POSTAL_CODE, length = 32)),
-        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.PICKUP_COUNTRY, length = 2)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_NAME, column = @Column(name = DeliveryId.PICKUP_CONTACT_NAME, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_PHONE, column = @Column(name = DeliveryId.PICKUP_CONTACT_PHONE, nullable = false, length = 64))
     })
@@ -73,11 +68,6 @@ public class Delivery {
     @Embedded
     @AttributeOverrides({
         @AttributeOverride(name = AddressContactId.Property.LINE1, column = @Column(name = DeliveryId.DESTINATION_LINE1, nullable = false)),
-        @AttributeOverride(name = AddressContactId.Property.LINE2, column = @Column(name = DeliveryId.DESTINATION_LINE2)),
-        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.DESTINATION_CITY, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.REGION, column = @Column(name = DeliveryId.DESTINATION_REGION, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.DESTINATION_POSTAL_CODE, length = 32)),
-        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.DESTINATION_COUNTRY, length = 2)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_NAME, column = @Column(name = DeliveryId.DESTINATION_CONTACT_NAME, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_PHONE, column = @Column(name = DeliveryId.DESTINATION_CONTACT_PHONE, nullable = false, length = 64))
     })
@@ -86,20 +76,8 @@ public class Delivery {
     @Column(name = DeliveryId.PACKAGE_WEIGHT_KG, nullable = false, precision = 12, scale = 4)
     private BigDecimal packageWeightKg;
 
-    @Column(name = DeliveryId.PACKAGE_LENGTH_CM, precision = 12, scale = 2)
-    private BigDecimal packageLengthCm;
-
-    @Column(name = DeliveryId.PACKAGE_WIDTH_CM, precision = 12, scale = 2)
-    private BigDecimal packageWidthCm;
-
-    @Column(name = DeliveryId.PACKAGE_HEIGHT_CM, precision = 12, scale = 2)
-    private BigDecimal packageHeightCm;
-
     @Column(name = DeliveryId.PACKAGE_DESCRIPTION, length = 1000)
     private String packageDescription;
-
-    @Column(name = DeliveryId.PACKAGE_FRAGILE, nullable = false)
-    private boolean packageFragile = false;
 
     @Column(name = DeliveryId.BASE_AMOUNT, precision = 19, scale = 4)
     private BigDecimal baseAmount;

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
@@ -61,10 +61,10 @@ public class Delivery {
     @AttributeOverrides({
         @AttributeOverride(name = AddressContactId.Property.LINE1, column = @Column(name = DeliveryId.PICKUP_LINE1, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.LINE2, column = @Column(name = DeliveryId.PICKUP_LINE2)),
-        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.PICKUP_CITY, nullable = false, length = 128)),
+        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.PICKUP_CITY, length = 128)),
         @AttributeOverride(name = AddressContactId.Property.REGION, column = @Column(name = DeliveryId.PICKUP_REGION, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.PICKUP_POSTAL_CODE, nullable = false, length = 32)),
-        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.PICKUP_COUNTRY, nullable = false, length = 2)),
+        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.PICKUP_POSTAL_CODE, length = 32)),
+        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.PICKUP_COUNTRY, length = 2)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_NAME, column = @Column(name = DeliveryId.PICKUP_CONTACT_NAME, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_PHONE, column = @Column(name = DeliveryId.PICKUP_CONTACT_PHONE, nullable = false, length = 64))
     })
@@ -74,10 +74,10 @@ public class Delivery {
     @AttributeOverrides({
         @AttributeOverride(name = AddressContactId.Property.LINE1, column = @Column(name = DeliveryId.DESTINATION_LINE1, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.LINE2, column = @Column(name = DeliveryId.DESTINATION_LINE2)),
-        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.DESTINATION_CITY, nullable = false, length = 128)),
+        @AttributeOverride(name = AddressContactId.Property.CITY, column = @Column(name = DeliveryId.DESTINATION_CITY, length = 128)),
         @AttributeOverride(name = AddressContactId.Property.REGION, column = @Column(name = DeliveryId.DESTINATION_REGION, length = 128)),
-        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.DESTINATION_POSTAL_CODE, nullable = false, length = 32)),
-        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.DESTINATION_COUNTRY, nullable = false, length = 2)),
+        @AttributeOverride(name = AddressContactId.Property.POSTAL_CODE, column = @Column(name = DeliveryId.DESTINATION_POSTAL_CODE, length = 32)),
+        @AttributeOverride(name = AddressContactId.Property.COUNTRY, column = @Column(name = DeliveryId.DESTINATION_COUNTRY, length = 2)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_NAME, column = @Column(name = DeliveryId.DESTINATION_CONTACT_NAME, nullable = false)),
         @AttributeOverride(name = AddressContactId.Property.CONTACT_PHONE, column = @Column(name = DeliveryId.DESTINATION_CONTACT_PHONE, nullable = false, length = 64))
     })

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AddressContactDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AddressContactDto.java
@@ -7,11 +7,6 @@ import lombok.Value;
 @Builder
 public class AddressContactDto {
     String line1;
-    String line2;
-    String city;
-    String region;
-    String postalCode;
-    String country;
     String contactName;
     String contactPhone;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AddressContactRequestDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AddressContactRequestDto.java
@@ -1,7 +1,6 @@
 package com.ubb.deliveryhub.delivery.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -11,28 +10,6 @@ public class AddressContactRequestDto {
     @NotBlank
     @Size(max = 255)
     private String line1;
-
-    @Size(max = 255)
-    private String line2;
-
-    @NotBlank
-    @Size(max = 128)
-    private String city;
-
-    @Size(max = 128)
-    private String region;
-
-    @NotBlank
-    @Size(max = 32)
-    private String postalCode;
-
-    /**
-     * ISO 3166-1 alpha-2 (e.g. RO).
-     */
-    @NotBlank
-    @Size(min = 2, max = 2)
-    @Pattern(regexp = "[A-Z]{2}", message = "must be two uppercase letters")
-    private String country;
 
     @NotBlank
     @Size(max = 255)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/CreateDeliveryRequest.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/CreateDeliveryRequest.java
@@ -21,11 +21,15 @@ public class CreateDeliveryRequest {
     @NotNull
     @Valid
     @JsonProperty("package")
-    private PackageRequestDto packageDetails;
+    private PackageRequestDto packageData;
 
     @NotNull
     private DeliveryType deliveryType;
 
     @Size(max = 2000)
     private String specialInstructions;
+
+    @NotNull
+    @Valid
+    private PricingRequestDto pricing;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryDetailDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryDetailDto.java
@@ -21,11 +21,7 @@ public class DeliveryDetailDto {
     AddressContactDto pickup;
     AddressContactDto destination;
     BigDecimal packageWeightKg;
-    BigDecimal packageLengthCm;
-    BigDecimal packageWidthCm;
-    BigDecimal packageHeightCm;
     String packageDescription;
-    boolean packageFragile;
     BigDecimal baseAmount;
     BigDecimal feeAmount;
     BigDecimal taxAmount;

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryDto.java
@@ -19,11 +19,7 @@ public class DeliveryDto {
     AddressContactDto pickup;
     AddressContactDto destination;
     BigDecimal packageWeightKg;
-    BigDecimal packageLengthCm;
-    BigDecimal packageWidthCm;
-    BigDecimal packageHeightCm;
     String packageDescription;
-    boolean packageFragile;
     BigDecimal baseAmount;
     BigDecimal feeAmount;
     BigDecimal taxAmount;

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliverySummaryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliverySummaryDto.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 
 /**
  * Row shape for customer delivery lists (#33 / Angular #35); camelCase for JSON.
+ * Route rendering uses destinationLine1 (main) and pickupLine1 (hint).
  */
 @Value
 @Builder
@@ -18,6 +19,6 @@ public class DeliverySummaryDto {
     Instant createdAt;
     BigDecimal totalAmount;
     String currency;
-    String pickupCity;
-    String destinationCity;
+    String pickupLine1;
+    String destinationLine1;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/PackageRequestDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/PackageRequestDto.java
@@ -1,9 +1,9 @@
 package com.ubb.deliveryhub.delivery.domain.dto;
 
 import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -14,22 +14,10 @@ public class PackageRequestDto {
 
     @NotNull
     @Positive(message = "must be greater than 0")
+    @DecimalMax(value = "999999")
     private BigDecimal weightKg;
 
-    @PositiveOrZero
-    @DecimalMax(value = "999999")
-    private BigDecimal lengthCm;
-
-    @PositiveOrZero
-    @DecimalMax(value = "999999")
-    private BigDecimal widthCm;
-
-    @PositiveOrZero
-    @DecimalMax(value = "999999")
-    private BigDecimal heightCm;
-
+    @NotBlank
     @Size(max = 1000)
     private String description;
-
-    private boolean fragile;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/PricingRequestDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/PricingRequestDto.java
@@ -1,0 +1,38 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class PricingRequestDto {
+
+    @NotNull
+    @PositiveOrZero
+    @DecimalMax("999999999999999.9999")
+    private BigDecimal baseAmount;
+
+    @NotNull
+    @PositiveOrZero
+    @DecimalMax("999999999999999.9999")
+    private BigDecimal feeAmount;
+
+    @NotNull
+    @PositiveOrZero
+    @DecimalMax("999999999999999.9999")
+    private BigDecimal taxAmount;
+
+    @NotNull
+    @PositiveOrZero
+    @DecimalMax("999999999999999.9999")
+    private BigDecimal totalAmount;
+
+    @NotBlank
+    @Size(max = 3)
+    private String currency;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/embedded/AddressContact.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/embedded/AddressContact.java
@@ -14,21 +14,6 @@ public class AddressContact {
     @Column(name = AddressContactId.LINE1, nullable = false)
     private String line1;
 
-    @Column(name = AddressContactId.LINE2)
-    private String line2;
-
-    @Column(name = AddressContactId.CITY, length = 128)
-    private String city;
-
-    @Column(name = AddressContactId.REGION, length = 128)
-    private String region;
-
-    @Column(name = AddressContactId.POSTAL_CODE, length = 32)
-    private String postalCode;
-
-    @Column(name = AddressContactId.COUNTRY, length = 2)
-    private String country;
-
     @Column(name = AddressContactId.CONTACT_NAME, nullable = false)
     private String contactName;
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/embedded/AddressContact.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/embedded/AddressContact.java
@@ -17,16 +17,16 @@ public class AddressContact {
     @Column(name = AddressContactId.LINE2)
     private String line2;
 
-    @Column(name = AddressContactId.CITY, nullable = false, length = 128)
+    @Column(name = AddressContactId.CITY, length = 128)
     private String city;
 
     @Column(name = AddressContactId.REGION, length = 128)
     private String region;
 
-    @Column(name = AddressContactId.POSTAL_CODE, nullable = false, length = 32)
+    @Column(name = AddressContactId.POSTAL_CODE, length = 32)
     private String postalCode;
 
-    @Column(name = AddressContactId.COUNTRY, nullable = false, length = 2)
+    @Column(name = AddressContactId.COUNTRY, length = 2)
     private String country;
 
     @Column(name = AddressContactId.CONTACT_NAME, nullable = false)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/id/AddressContactId.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/id/AddressContactId.java
@@ -7,11 +7,6 @@ package com.ubb.deliveryhub.delivery.domain.id;
 public final class AddressContactId {
 
     public static final String LINE1 = "line1";
-    public static final String LINE2 = "line2";
-    public static final String CITY = "city";
-    public static final String REGION = "region";
-    public static final String POSTAL_CODE = "postal_code";
-    public static final String COUNTRY = "country";
     public static final String CONTACT_NAME = "contact_name";
     public static final String CONTACT_PHONE = "contact_phone";
 
@@ -20,11 +15,6 @@ public final class AddressContactId {
      */
     public static final class Property {
         public static final String LINE1 = "line1";
-        public static final String LINE2 = "line2";
-        public static final String CITY = "city";
-        public static final String REGION = "region";
-        public static final String POSTAL_CODE = "postalCode";
-        public static final String COUNTRY = "country";
         public static final String CONTACT_NAME = "contactName";
         public static final String CONTACT_PHONE = "contactPhone";
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/id/DeliveryId.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/id/DeliveryId.java
@@ -14,29 +14,15 @@ public final class DeliveryId {
     public static final String DELIVERY_TYPE = "delivery_type";
 
     public static final String PICKUP_LINE1 = "pickup_line1";
-    public static final String PICKUP_LINE2 = "pickup_line2";
-    public static final String PICKUP_CITY = "pickup_city";
-    public static final String PICKUP_REGION = "pickup_region";
-    public static final String PICKUP_POSTAL_CODE = "pickup_postal_code";
-    public static final String PICKUP_COUNTRY = "pickup_country";
     public static final String PICKUP_CONTACT_NAME = "pickup_contact_name";
     public static final String PICKUP_CONTACT_PHONE = "pickup_contact_phone";
 
     public static final String DESTINATION_LINE1 = "destination_line1";
-    public static final String DESTINATION_LINE2 = "destination_line2";
-    public static final String DESTINATION_CITY = "destination_city";
-    public static final String DESTINATION_REGION = "destination_region";
-    public static final String DESTINATION_POSTAL_CODE = "destination_postal_code";
-    public static final String DESTINATION_COUNTRY = "destination_country";
     public static final String DESTINATION_CONTACT_NAME = "destination_contact_name";
     public static final String DESTINATION_CONTACT_PHONE = "destination_contact_phone";
 
     public static final String PACKAGE_WEIGHT_KG = "package_weight_kg";
-    public static final String PACKAGE_LENGTH_CM = "package_length_cm";
-    public static final String PACKAGE_WIDTH_CM = "package_width_cm";
-    public static final String PACKAGE_HEIGHT_CM = "package_height_cm";
     public static final String PACKAGE_DESCRIPTION = "package_description";
-    public static final String PACKAGE_FRAGILE = "package_fragile";
 
     public static final String BASE_AMOUNT = "base_amount";
     public static final String FEE_AMOUNT = "fee_amount";

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -39,11 +39,7 @@ public final class DeliveryMapper {
         d.setDestination(toEmbedded(request.getDestination()));
         PackageRequestDto pkg = request.getPackageData();
         d.setPackageWeightKg(normalizeWeightKg(pkg.getWeightKg()));
-        d.setPackageLengthCm(null);
-        d.setPackageWidthCm(null);
-        d.setPackageHeightCm(null);
         d.setPackageDescription(pkg.getDescription());
-        d.setPackageFragile(false);
         d.setSpecialInstructions(request.getSpecialInstructions());
         d.setBaseAmount(request.getPricing().getBaseAmount());
         d.setFeeAmount(request.getPricing().getFeeAmount());
@@ -56,19 +52,14 @@ public final class DeliveryMapper {
     public static AddressContact toEmbedded(AddressContactRequestDto dto) {
         AddressContact a = new AddressContact();
         a.setLine1(dto.getLine1());
-        a.setLine2(null);
-        a.setCity(null);
-        a.setRegion(null);
-        a.setPostalCode(null);
-        a.setCountry(null);
         a.setContactName(dto.getContactName());
         a.setContactPhone(dto.getContactPhone());
         return a;
     }
 
     public static DeliverySummaryDto toSummaryDto(Delivery d) {
-        String pickupCity = d.getPickup() != null ? d.getPickup().getCity() : null;
-        String destinationCity = d.getDestination() != null ? d.getDestination().getCity() : null;
+        String pickupLine1 = d.getPickup() != null ? d.getPickup().getLine1() : null;
+        String destinationLine1 = d.getDestination() != null ? d.getDestination().getLine1() : null;
         return DeliverySummaryDto.builder()
             .id(d.getId().toString())
             .status(d.getStatus().name())
@@ -76,8 +67,8 @@ public final class DeliveryMapper {
             .createdAt(d.getCreatedAt())
             .totalAmount(d.getTotalAmount())
             .currency(d.getCurrency())
-            .pickupCity(pickupCity)
-            .destinationCity(destinationCity)
+            .pickupLine1(pickupLine1)
+            .destinationLine1(destinationLine1)
             .build();
     }
 
@@ -90,11 +81,7 @@ public final class DeliveryMapper {
             .pickup(toDto(d.getPickup()))
             .destination(toDto(d.getDestination()))
             .packageWeightKg(d.getPackageWeightKg())
-            .packageLengthCm(d.getPackageLengthCm())
-            .packageWidthCm(d.getPackageWidthCm())
-            .packageHeightCm(d.getPackageHeightCm())
             .packageDescription(d.getPackageDescription())
-            .packageFragile(d.isPackageFragile())
             .baseAmount(d.getBaseAmount())
             .feeAmount(d.getFeeAmount())
             .taxAmount(d.getTaxAmount())
@@ -122,11 +109,7 @@ public final class DeliveryMapper {
             .pickup(toDto(d.getPickup()))
             .destination(toDto(d.getDestination()))
             .packageWeightKg(d.getPackageWeightKg())
-            .packageLengthCm(d.getPackageLengthCm())
-            .packageWidthCm(d.getPackageWidthCm())
-            .packageHeightCm(d.getPackageHeightCm())
             .packageDescription(d.getPackageDescription())
-            .packageFragile(d.isPackageFragile())
             .baseAmount(d.getBaseAmount())
             .feeAmount(d.getFeeAmount())
             .taxAmount(d.getTaxAmount())
@@ -161,11 +144,6 @@ public final class DeliveryMapper {
         }
         return AddressContactDto.builder()
             .line1(a.getLine1())
-            .line2(a.getLine2())
-            .city(a.getCity())
-            .region(a.getRegion())
-            .postalCode(a.getPostalCode())
-            .country(a.getCountry())
             .contactName(a.getContactName())
             .contactPhone(a.getContactPhone())
             .build();

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -2,7 +2,6 @@ package com.ubb.deliveryhub.delivery.service;
 
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
-import com.ubb.deliveryhub.delivery.domain.MoneySnapshot;
 import com.ubb.deliveryhub.delivery.domain.dto.AddressContactDto;
 import com.ubb.deliveryhub.delivery.domain.dto.AddressContactRequestDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CourierSummaryDto;
@@ -22,7 +21,6 @@ import java.util.List;
 public final class DeliveryMapper {
 
     private static final int SCALE_WEIGHT_KG = 4;
-    private static final int SCALE_CM = 2;
 
     private DeliveryMapper() {
     }
@@ -30,7 +28,6 @@ public final class DeliveryMapper {
     public static Delivery newDeliveryEntity(
         User customer,
         CreateDeliveryRequest request,
-        MoneySnapshot pricing,
         String trackingCode
     ) {
         Delivery d = new Delivery();
@@ -40,30 +37,30 @@ public final class DeliveryMapper {
         d.setDeliveryType(request.getDeliveryType());
         d.setPickup(toEmbedded(request.getPickup()));
         d.setDestination(toEmbedded(request.getDestination()));
-        PackageRequestDto pkg = request.getPackageDetails();
+        PackageRequestDto pkg = request.getPackageData();
         d.setPackageWeightKg(normalizeWeightKg(pkg.getWeightKg()));
-        d.setPackageLengthCm(normalizeCm(pkg.getLengthCm()));
-        d.setPackageWidthCm(normalizeCm(pkg.getWidthCm()));
-        d.setPackageHeightCm(normalizeCm(pkg.getHeightCm()));
+        d.setPackageLengthCm(null);
+        d.setPackageWidthCm(null);
+        d.setPackageHeightCm(null);
         d.setPackageDescription(pkg.getDescription());
-        d.setPackageFragile(pkg.isFragile());
+        d.setPackageFragile(false);
         d.setSpecialInstructions(request.getSpecialInstructions());
-        d.setBaseAmount(pricing.baseAmount());
-        d.setFeeAmount(pricing.feeAmount());
-        d.setTaxAmount(pricing.taxAmount());
-        d.setTotalAmount(pricing.totalAmount());
-        d.setCurrency(pricing.currency());
+        d.setBaseAmount(request.getPricing().getBaseAmount());
+        d.setFeeAmount(request.getPricing().getFeeAmount());
+        d.setTaxAmount(request.getPricing().getTaxAmount());
+        d.setTotalAmount(request.getPricing().getTotalAmount());
+        d.setCurrency(request.getPricing().getCurrency());
         return d;
     }
 
     public static AddressContact toEmbedded(AddressContactRequestDto dto) {
         AddressContact a = new AddressContact();
         a.setLine1(dto.getLine1());
-        a.setLine2(dto.getLine2());
-        a.setCity(dto.getCity());
-        a.setRegion(dto.getRegion());
-        a.setPostalCode(dto.getPostalCode());
-        a.setCountry(dto.getCountry());
+        a.setLine2(null);
+        a.setCity(null);
+        a.setRegion(null);
+        a.setPostalCode(null);
+        a.setCountry(null);
         a.setContactName(dto.getContactName());
         a.setContactPhone(dto.getContactPhone());
         return a;
@@ -154,18 +151,8 @@ public final class DeliveryMapper {
             .build();
     }
 
-    /**
-     * Matches {@link PricingService} weight rounding so persisted kg aligns with the pricing snapshot.
-     */
     static BigDecimal normalizeWeightKg(BigDecimal weightKg) {
         return weightKg.setScale(SCALE_WEIGHT_KG, RoundingMode.HALF_UP);
-    }
-
-    static BigDecimal normalizeCm(BigDecimal cm) {
-        if (cm == null) {
-            return null;
-        }
-        return cm.setScale(SCALE_CM, RoundingMode.HALF_UP);
     }
 
     private static AddressContactDto toDto(AddressContact a) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -4,7 +4,6 @@ import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
-import com.ubb.deliveryhub.delivery.domain.MoneySnapshot;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
@@ -53,7 +52,6 @@ public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
     private final UserRepository userRepository;
-    private final PricingService pricingService;
     private final DeliveryAuthorization deliveryAuthorization;
     private final SecureRandom secureRandom = new SecureRandom();
 
@@ -63,11 +61,9 @@ public class DeliveryService {
         User customer = userRepository.findById(customerId)
             .orElseThrow(() -> new EntityNotFoundException("User with id %s not found".formatted(customerId)));
 
-        MoneySnapshot pricing = pricingService.calculate(request.getDeliveryType(), request.getPackageDetails());
-
         for (int attempt = 0; attempt < TRACKING_CODE_SAVE_ATTEMPTS; attempt++) {
             String trackingCode = "DH-" + randomAlphanumeric(TRACKING_BODY_LEN);
-            Delivery delivery = DeliveryMapper.newDeliveryEntity(customer, request, pricing, trackingCode);
+            Delivery delivery = DeliveryMapper.newDeliveryEntity(customer, request, trackingCode);
             delivery.setStatus(DeliveryStatus.CREATED);
             try {
                 Delivery saved = deliveryRepository.save(delivery);

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/PricingService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/PricingService.java
@@ -9,17 +9,17 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * <p>Deterministic, side-effect-free pricing used only server-side (never trust client totals).</p>
+ * <p>Deterministic, side-effect-free pricing utility retained for reference and potential reuse.</p>
+ * <p>Create-delivery currently persists a client-provided pricing snapshot directly.</p>
  *
  * <h2>MVP rules (dissertation / prototype)</h2>
  * <ul>
  *   <li><b>STANDARD</b> — transport charge grows with weight using simple tiers (RON).</li>
  *   <li><b>EXPRESS</b> — applies a rush surcharge on top of the STANDARD transport component.</li>
- *   <li><b>Fragile</b> — adds a flat handling fee.</li>
- *   <li><b>VAT</b> — fixed 19% applied to (transport + surcharges + fragile fee).</li>
+ *   <li><b>VAT</b> — fixed 19% applied to the computed transport amount.</li>
  * </ul>
  *
- * <p><b>Tiered STANDARD transport (weight kg → base before express/fragile/VAT):</b></p>
+ * <p><b>Tiered STANDARD transport (weight kg → base before express/VAT):</b></p>
  * <pre>
  * w ≤ 2   → 12.00 RON
  * 2 &lt; w ≤ 15 → 12 + (w − 2) × 3
@@ -38,7 +38,6 @@ public class PricingService {
     private static final BigDecimal VAT_RATE = new BigDecimal("0.19");
     private static final BigDecimal EXPRESS_TRANSPORT_MULTIPLIER = new BigDecimal("1.25");
     private static final BigDecimal EXPRESS_RUSH_FLAT = new BigDecimal("18.00");
-    private static final BigDecimal FRAGILE_FEE = new BigDecimal("5.0000");
     private static final String CURRENCY = "RON";
 
     public MoneySnapshot calculate(DeliveryType deliveryType, PackageRequestDto pkg) {
@@ -48,10 +47,8 @@ public class PricingService {
             transport = transport.multiply(EXPRESS_TRANSPORT_MULTIPLIER).add(EXPRESS_RUSH_FLAT).setScale(4, RoundingMode.HALF_UP);
         }
 
-        BigDecimal fragileFee = pkg.isFragile() ? FRAGILE_FEE : BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
-
         BigDecimal baseAmount = transport;
-        BigDecimal feeAmount = fragileFee;
+        BigDecimal feeAmount = BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
 
         BigDecimal taxable = baseAmount.add(feeAmount);
         BigDecimal taxAmount = taxable.multiply(VAT_RATE).setScale(4, RoundingMode.HALF_UP);

--- a/backend/src/main/resources/db/migration/V5__relax_delivery_address_requirements.sql
+++ b/backend/src/main/resources/db/migration/V5__relax_delivery_address_requirements.sql
@@ -1,0 +1,10 @@
+-- Align create-delivery payload with simplified frontend address shape.
+-- Keep line1/contact_name/contact_phone required, make city/postal/country optional.
+
+ALTER TABLE deliveries
+    ALTER COLUMN pickup_city DROP NOT NULL,
+    ALTER COLUMN pickup_postal_code DROP NOT NULL,
+    ALTER COLUMN pickup_country DROP NOT NULL,
+    ALTER COLUMN destination_city DROP NOT NULL,
+    ALTER COLUMN destination_postal_code DROP NOT NULL,
+    ALTER COLUMN destination_country DROP NOT NULL;

--- a/backend/src/main/resources/db/migration/V6__drop_unused_delivery_columns.sql
+++ b/backend/src/main/resources/db/migration/V6__drop_unused_delivery_columns.sql
@@ -1,0 +1,18 @@
+-- Drop deliveries columns that are not set by the current UI create flow.
+-- Simplified payload keeps only line1/contact fields for addresses and weight/description for package.
+
+ALTER TABLE deliveries
+    DROP COLUMN IF EXISTS pickup_line2,
+    DROP COLUMN IF EXISTS pickup_city,
+    DROP COLUMN IF EXISTS pickup_region,
+    DROP COLUMN IF EXISTS pickup_postal_code,
+    DROP COLUMN IF EXISTS pickup_country,
+    DROP COLUMN IF EXISTS destination_line2,
+    DROP COLUMN IF EXISTS destination_city,
+    DROP COLUMN IF EXISTS destination_region,
+    DROP COLUMN IF EXISTS destination_postal_code,
+    DROP COLUMN IF EXISTS destination_country,
+    DROP COLUMN IF EXISTS package_length_cm,
+    DROP COLUMN IF EXISTS package_width_cm,
+    DROP COLUMN IF EXISTS package_height_cm,
+    DROP COLUMN IF EXISTS package_fragile;

--- a/frontend/src/app/core/services/delivery/delivery.ts
+++ b/frontend/src/app/core/services/delivery/delivery.ts
@@ -124,6 +124,6 @@ export class DeliveryService extends BaseService {
     return serverField
       .replaceAll('[', '.')
       .replaceAll(']', '')
-      .replace(/^packageDetails(\.|$)/, 'package$1');
+      .replace(/^package(Data|Details)(\.|$)/, 'package$2');
   }
 }

--- a/frontend/src/app/core/services/delivery/delivery.ts
+++ b/frontend/src/app/core/services/delivery/delivery.ts
@@ -1,7 +1,10 @@
-import { HttpParams } from '@angular/common/http';
+import { HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 import { BaseService } from '@core/services/base.service';
 import {
+  CreateDeliveryRequest,
+  DeliveryCreatedResponse,
   DeliveryListQuery,
   DeliverySummaryDto,
   PageDto,
@@ -12,6 +15,15 @@ import { Observable } from 'rxjs';
   providedIn: 'root',
 })
 export class DeliveryService extends BaseService {
+  create(
+    payload: CreateDeliveryRequest,
+  ): Observable<DeliveryCreatedResponse> {
+    return this.httpClient.post<DeliveryCreatedResponse>(
+      `${this.baseUrl}/deliveries`,
+      payload,
+    );
+  }
+
   listForCurrentCustomer(
     query: DeliveryListQuery = {},
   ): Observable<PageDto<DeliverySummaryDto>> {
@@ -32,5 +44,86 @@ export class DeliveryService extends BaseService {
         params,
       },
     );
+  }
+
+  applyValidationErrors(
+    form: FormGroup,
+    error: HttpErrorResponse,
+  ): boolean {
+    if (error.status !== 400 || !error.error) {
+      return false;
+    }
+
+    const fieldErrors = this.extractFieldErrors(error.error);
+    if (fieldErrors.length === 0) {
+      return false;
+    }
+
+    let applied = false;
+    for (const [rawField, message] of fieldErrors) {
+      const controlPath = this.normalizeControlPath(rawField);
+      const control = form.get(controlPath);
+      if (!control) {
+        continue;
+      }
+      control.setErrors({
+        ...(control.errors ?? {}),
+        server: message,
+      });
+      control.markAsTouched();
+      applied = true;
+    }
+
+    return applied;
+  }
+
+  private extractFieldErrors(errorBody: unknown): Array<[string, string]> {
+    if (typeof errorBody !== 'object' || errorBody === null) {
+      return [];
+    }
+
+    const candidates: Array<[string, string]> = [];
+    const body = errorBody as {
+      errors?: Record<string, unknown>;
+      violations?: unknown[];
+    };
+
+    if (body.errors && typeof body.errors === 'object') {
+      for (const [field, value] of Object.entries(body.errors)) {
+        if (Array.isArray(value) && value.length > 0) {
+          candidates.push([field, String(value[0])]);
+          continue;
+        }
+        if (typeof value === 'string' && value.length > 0) {
+          candidates.push([field, value]);
+        }
+      }
+    }
+
+    if (Array.isArray(body.violations)) {
+      for (const violation of body.violations) {
+        if (!violation || typeof violation !== 'object') {
+          continue;
+        }
+        const item = violation as { field?: unknown; message?: unknown };
+        if (
+          typeof item.field === 'string' &&
+          item.field.length > 0 &&
+          typeof item.message === 'string' &&
+          item.message.length > 0
+        ) {
+          candidates.push([item.field, item.message]);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  private normalizeControlPath(serverField: string): string {
+    return serverField
+      .replaceAll('[', '.')
+      .replaceAll(']', '')
+      .replace(/^packageDetails(\.|$)/, 'package$1');
   }
 }

--- a/frontend/src/app/core/services/enum/delivery.types.ts
+++ b/frontend/src/app/core/services/enum/delivery.types.ts
@@ -22,3 +22,74 @@ export interface DeliveryListQuery {
   size?: number;
   status?: string;
 }
+
+export type DeliveryType = 'STANDARD' | 'EXPRESS';
+
+export interface AddressContactRequest {
+  line1: string;
+  line2?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  country?: string;
+  contactName: string;
+  contactPhone: string;
+}
+
+export interface PackageRequest {
+  weightKg: number;
+  lengthCm?: number;
+  widthCm?: number;
+  heightCm?: number;
+  description?: string;
+  fragile?: boolean;
+}
+
+export interface CreateDeliveryRequest {
+  pickup: AddressContactRequest;
+  destination: AddressContactRequest;
+  package: PackageRequest;
+  deliveryType: DeliveryType;
+  specialInstructions?: string;
+}
+
+export interface DeliveryCreatedResponse {
+  id: string;
+  trackingCode: string;
+  status: string;
+  deliveryType: DeliveryType;
+  pickup: {
+    line1: string;
+    line2?: string;
+    city: string;
+    region?: string;
+    postalCode: string;
+    country: string;
+    contactName: string;
+    contactPhone: string;
+  };
+  destination: {
+    line1: string;
+    line2?: string;
+    city: string;
+    region?: string;
+    postalCode: string;
+    country: string;
+    contactName: string;
+    contactPhone: string;
+  };
+  packageWeightKg: number;
+  packageLengthCm?: number;
+  packageWidthCm?: number;
+  packageHeightCm?: number;
+  packageDescription?: string;
+  packageFragile: boolean;
+  baseAmount: number;
+  feeAmount: number;
+  taxAmount: number;
+  totalAmount: number;
+  currency: string;
+  specialInstructions?: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/app/core/services/enum/delivery.types.ts
+++ b/frontend/src/app/core/services/enum/delivery.types.ts
@@ -13,8 +13,8 @@ export interface DeliverySummaryDto {
   createdAt: string;
   totalAmount: number;
   currency: string;
-  pickupCity: string;
-  destinationCity: string;
+  pickupLine1: string;
+  destinationLine1: string;
 }
 
 export interface DeliveryListQuery {
@@ -27,22 +27,13 @@ export type DeliveryType = 'STANDARD' | 'EXPRESS';
 
 export interface AddressContactRequest {
   line1: string;
-  line2?: string;
-  city?: string;
-  region?: string;
-  postalCode?: string;
-  country?: string;
   contactName: string;
   contactPhone: string;
 }
 
 export interface PackageRequest {
   weightKg: number;
-  lengthCm?: number;
-  widthCm?: number;
-  heightCm?: number;
-  description?: string;
-  fragile?: boolean;
+  description: string;
 }
 
 export interface CreateDeliveryRequest {
@@ -51,6 +42,13 @@ export interface CreateDeliveryRequest {
   package: PackageRequest;
   deliveryType: DeliveryType;
   specialInstructions?: string;
+  pricing: {
+    baseAmount: number;
+    feeAmount: number;
+    taxAmount: number;
+    totalAmount: number;
+    currency: string;
+  };
 }
 
 export interface DeliveryCreatedResponse {
@@ -58,38 +56,9 @@ export interface DeliveryCreatedResponse {
   trackingCode: string;
   status: string;
   deliveryType: DeliveryType;
-  pickup: {
-    line1: string;
-    line2?: string;
-    city: string;
-    region?: string;
-    postalCode: string;
-    country: string;
-    contactName: string;
-    contactPhone: string;
-  };
-  destination: {
-    line1: string;
-    line2?: string;
-    city: string;
-    region?: string;
-    postalCode: string;
-    country: string;
-    contactName: string;
-    contactPhone: string;
-  };
-  packageWeightKg: number;
-  packageLengthCm?: number;
-  packageWidthCm?: number;
-  packageHeightCm?: number;
-  packageDescription?: string;
-  packageFragile: boolean;
   baseAmount: number;
   feeAmount: number;
   taxAmount: number;
   totalAmount: number;
   currency: string;
-  specialInstructions?: string;
-  createdAt: string;
-  updatedAt: string;
 }

--- a/frontend/src/app/features/customer/customer.routes.ts
+++ b/frontend/src/app/features/customer/customer.routes.ts
@@ -14,8 +14,14 @@ export const customerRoutes: Routes = [
   },
   {
     path: 'create',
-    loadComponent: loadStub,
-    data: { pageTitle: 'Create New Delivery' },
+    loadComponent: () =>
+      import('./pages/create-delivery/create-delivery').then(
+        (m) => m.CreateDeliveryPage,
+      ),
+    data: {
+      pageTitle: 'Create New Delivery',
+      subtitle: 'Fill in the delivery details below',
+    },
   },
   {
     path: 'tracking',

--- a/frontend/src/app/features/customer/customer.routes.ts
+++ b/frontend/src/app/features/customer/customer.routes.ts
@@ -8,7 +8,10 @@ const loadStub = () =>
 export const customerRoutes: Routes = [
   {
     path: '',
-    data: { pageTitle: 'Dashboard' },
+    data: {
+      pageTitle: 'Dashboard',
+      subtitle: "Welcome back! Here's your delivery overview",
+    },
     loadComponent: () =>
       import('./pages/customer-home/customer-home').then((m) => m.CustomerHome),
   },

--- a/frontend/src/app/features/customer/pages/create-delivery/create-delivery-redesign.html
+++ b/frontend/src/app/features/customer/pages/create-delivery/create-delivery-redesign.html
@@ -1,0 +1,206 @@
+<div class="create-page">
+  <div class="mx-auto w-full max-w-[1200px] p-4 md:p-6">
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <div class="space-y-5 lg:col-span-2">
+          <p-card formGroupName="pickup" class="section-card">
+            <div class="section-header">
+              <div class="card-title">
+                <span class="title-icon title-icon-success"><i class="pi pi-map-marker"></i></span>
+                <span class="card-title-text">Pickup Information</span>
+              </div>
+            </div>
+            <div class="section-body space-y-3">
+              <div>
+                <label class="field-label" for="pickup-line1">Pickup Address</label>
+                <input
+                  id="pickup-line1"
+                  pInputText
+                  class="w-full"
+                  [class.input-invalid]="isFieldInvalid('pickup.line1')"
+                  formControlName="line1"
+                  placeholder="Enter full address"
+                />
+                @if (fieldError('pickup.line1'); as error) { <small class="field-error">{{ error }}</small> }
+              </div>
+              <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <div>
+                  <label class="field-label" for="pickup-contactName">Contact Name</label>
+                  <input
+                    id="pickup-contactName"
+                    pInputText
+                    class="w-full"
+                    [class.input-invalid]="isFieldInvalid('pickup.contactName')"
+                    formControlName="contactName"
+                    placeholder="Enter name"
+                  />
+                  @if (fieldError('pickup.contactName'); as error) { <small class="field-error">{{ error }}</small> }
+                </div>
+                <div>
+                  <label class="field-label" for="pickup-contactPhone">Contact Phone</label>
+                  <input
+                    id="pickup-contactPhone"
+                    pInputText
+                    class="w-full"
+                    [class.input-invalid]="isFieldInvalid('pickup.contactPhone')"
+                    formControlName="contactPhone"
+                    placeholder="Enter phone"
+                  />
+                  @if (fieldError('pickup.contactPhone'); as error) { <small class="field-error">{{ error }}</small> }
+                </div>
+              </div>
+            </div>
+          </p-card>
+
+          <p-card formGroupName="destination" class="section-card">
+            <div class="section-header">
+              <div class="card-title">
+                <span class="title-icon title-icon-danger"><i class="pi pi-map-marker"></i></span>
+                <span class="card-title-text">Destination Information</span>
+              </div>
+            </div>
+            <div class="section-body space-y-3">
+              <div>
+                <label class="field-label" for="destination-line1">Destination Address</label>
+                <input
+                  id="destination-line1"
+                  pInputText
+                  class="w-full"
+                  [class.input-invalid]="isFieldInvalid('destination.line1')"
+                  formControlName="line1"
+                  placeholder="Enter full address"
+                />
+                @if (fieldError('destination.line1'); as error) { <small class="field-error">{{ error }}</small> }
+              </div>
+              <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <div>
+                  <label class="field-label" for="destination-contactName">Contact Name</label>
+                  <input
+                    id="destination-contactName"
+                    pInputText
+                    class="w-full"
+                    [class.input-invalid]="isFieldInvalid('destination.contactName')"
+                    formControlName="contactName"
+                    placeholder="Enter name"
+                  />
+                  @if (fieldError('destination.contactName'); as error) { <small class="field-error">{{ error }}</small> }
+                </div>
+                <div>
+                  <label class="field-label" for="destination-contactPhone">Contact Phone</label>
+                  <input
+                    id="destination-contactPhone"
+                    pInputText
+                    class="w-full"
+                    [class.input-invalid]="isFieldInvalid('destination.contactPhone')"
+                    formControlName="contactPhone"
+                    placeholder="Enter phone"
+                  />
+                  @if (fieldError('destination.contactPhone'); as error) { <small class="field-error">{{ error }}</small> }
+                </div>
+              </div>
+            </div>
+          </p-card>
+
+          <p-card formGroupName="package" class="section-card">
+            <div class="section-header">
+              <div class="card-title">
+                <span class="title-icon title-icon-info"><i class="pi pi-box"></i></span>
+                <span class="card-title-text">Package Details</span>
+              </div>
+            </div>
+            <div class="section-body space-y-3">
+              <div>
+                <label class="field-label" for="package-description">Package Description</label>
+                <textarea
+                  id="package-description"
+                  pTextarea
+                  rows="3"
+                  class="w-full"
+                  [class.input-invalid]="isFieldInvalid('package.description')"
+                  formControlName="description"
+                  placeholder="Describe the package contents"
+                ></textarea>
+                @if (fieldError('package.description'); as error) { <small class="field-error">{{ error }}</small> }
+              </div>
+              <div>
+                <label class="field-label" for="package-weightKg">Estimated Weight (kg)</label>
+                <p-inputnumber
+                  inputId="package-weightKg"
+                  [min]="0.01"
+                  [minFractionDigits]="2"
+                  [maxFractionDigits]="2"
+                  [useGrouping]="false"
+                  [inputStyleClass]="isFieldInvalid('package.weightKg') ? 'input-invalid' : ''"
+                  formControlName="weightKg"
+                />
+                @if (fieldError('package.weightKg'); as error) { <small class="field-error">{{ error }}</small> }
+              </div>
+              <div>
+                <label class="field-label" for="specialInstructions">Special Instructions (Optional)</label>
+                <textarea
+                  id="specialInstructions"
+                  pTextarea
+                  rows="3"
+                  class="w-full"
+                  [class.input-invalid]="isFieldInvalid('specialInstructions')"
+                  [formControl]="form.controls.specialInstructions"
+                  placeholder="Any special handling instructions"
+                ></textarea>
+              </div>
+            </div>
+          </p-card>
+        </div>
+
+        <div class="space-y-5">
+          <p-card class="section-card">
+            <div class="section-header">
+              <div class="card-title">
+                <span class="card-title-text">Delivery Type</span>
+              </div>
+            </div>
+            <div class="section-body space-y-2">
+              @for (type of deliveryTypeCards; track type.value) {
+                <button type="button" class="type-option" [class.type-option-active]="isDeliveryTypeSelected(type.value)" (click)="selectDeliveryType(type.value)">
+                  <div class="mb-1 flex items-center justify-between">
+                    <span class="type-option-title text-[13px] font-semibold">{{ type.label }}</span>
+                    <i class="pi pi-clock text-[12px] text-p-text-muted"></i>
+                  </div>
+                  <div class="type-option-meta flex items-center justify-between text-[12px] text-p-text-muted">
+                    <span>{{ type.eta }}</span>
+                    <span class="font-semibold">${{ type.previewBase }}</span>
+                  </div>
+                </button>
+              }
+            </div>
+          </p-card>
+
+          <p-card class="section-card">
+            <div class="section-header">
+              <div class="card-title">
+                <span class="title-icon title-icon-success"><i class="pi pi-dollar"></i></span>
+                <span class="card-title-text">Price Summary</span>
+              </div>
+            </div>
+            <div class="section-body">
+              <div class="summary-row"><span>Base Price</span><span class="value">${{ previewPricing().baseAmount.toFixed(2) }}</span></div>
+              <div class="summary-row"><span>Service Fee</span><span class="value">${{ previewPricing().feeAmount.toFixed(2) }}</span></div>
+              <div class="summary-row"><span>Tax (10%)</span><span class="value">${{ previewPricing().taxAmount.toFixed(2) }}</span></div>
+              <div class="summary-total"><span>Total</span><span>${{ previewPricing().totalAmount.toFixed(2) }}</span></div>
+            </div>
+          </p-card>
+
+          <div class="action-buttons">
+            <p-button type="submit" label="Create Delivery Request" styleClass="w-full" [loading]="saving()" [disabled]="saving()" />
+            <p-button
+              type="button"
+              label="Cancel"
+              styleClass="w-full cancel-btn"
+              [outlined]="true"
+              (onClick)="cancel()"
+            />
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/frontend/src/app/features/customer/pages/create-delivery/create-delivery.scss
+++ b/frontend/src/app/features/customer/pages/create-delivery/create-delivery.scss
@@ -1,0 +1,183 @@
+:host {
+  display: block;
+}
+
+.create-page {
+  background: var(--p-surface-ground);
+}
+
+p-inputnumber {
+  width: 100%;
+}
+
+.field-label {
+  margin-bottom: 0.25rem;
+  display: block;
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+}
+
+.field-error {
+  margin-top: 0.25rem;
+  display: block;
+  font-size: 0.75rem;
+  color: var(--p-red-500);
+}
+
+:host ::ng-deep .input-invalid {
+  border-color: var(--p-red-500) !important;
+}
+
+:host ::ng-deep .input-invalid:enabled:focus {
+  border-color: var(--p-red-500) !important;
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--p-red-500) 20%, transparent);
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+}
+
+.card-title-text {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  line-height: 1;
+}
+
+.title-icon {
+  display: inline-flex;
+  height: 1.5rem;
+  width: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--p-content-border-radius);
+  font-size: 0.75rem;
+}
+
+.title-icon i {
+  line-height: 1;
+}
+
+.title-icon-success {
+  background: color-mix(in srgb, var(--p-green-500) 18%, transparent);
+  color: var(--p-green-600);
+}
+
+.title-icon-danger {
+  background: color-mix(in srgb, var(--p-red-500) 18%, transparent);
+  color: var(--p-red-600);
+}
+
+.title-icon-info {
+  background: color-mix(in srgb, var(--p-cyan-500) 18%, transparent);
+  color: var(--p-cyan-600);
+}
+
+.type-option {
+  width: 100%;
+  cursor: pointer;
+  border-radius: var(--p-content-border-radius);
+  border: 1px solid var(--p-surface-border);
+  background: var(--p-surface-card);
+  padding: 0.75rem;
+  text-align: left;
+  transition: all 0.15s ease;
+}
+
+.type-option:hover {
+  border-color: var(--p-primary-color);
+}
+
+.type-option-active {
+  border-color: var(--p-primary-color);
+  background: color-mix(in srgb, var(--p-primary-color) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--p-primary-color) 50%, transparent);
+}
+
+.type-option-active .type-option-title {
+  color: var(--p-primary-color);
+}
+
+.type-option-active .type-option-meta {
+  color: color-mix(in srgb, var(--p-primary-color) 70%, var(--p-text-muted-color));
+}
+
+.summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+  padding-block: 0.25rem;
+}
+
+.summary-row .value {
+  color: var(--p-text-color);
+  font-weight: 500;
+}
+
+.summary-total {
+  margin-top: 0.5rem;
+  border-top: 1px solid var(--p-surface-border);
+  padding-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--p-text-color);
+  font-size: 0.9375rem;
+  font-weight: 700;
+}
+
+.summary-total span:last-child {
+  color: var(--p-primary-color);
+  font-size: 1.125rem;
+}
+
+:host ::ng-deep .section-card.p-card {
+  border: 1px solid var(--p-surface-border);
+  box-shadow: none;
+}
+
+:host ::ng-deep .section-card .p-card-body {
+  padding: 0;
+}
+
+:host ::ng-deep .section-card .p-card-content {
+  padding: 0;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  min-height: 3.75rem;
+  padding: 0 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--p-surface-border) 65%, #aeb7c2);
+}
+
+.section-body {
+  padding: 0.875rem 1rem 1rem;
+}
+
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+:host ::ng-deep .cancel-btn.p-button {
+  border-color: var(--p-primary-color);
+  background: color-mix(in srgb, var(--p-primary-color) 5%, #ffffff);
+  color: var(--p-primary-color);
+}
+
+:host ::ng-deep .cancel-btn.p-button:hover {
+  border-color: var(--p-primary-color);
+  background: color-mix(in srgb, var(--p-primary-color) 10%, #ffffff);
+  color: var(--p-primary-color);
+}

--- a/frontend/src/app/features/customer/pages/create-delivery/create-delivery.ts
+++ b/frontend/src/app/features/customer/pages/create-delivery/create-delivery.ts
@@ -1,0 +1,242 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { DeliveryService } from '@core/services/delivery/delivery';
+import {
+  CreateDeliveryRequest,
+  DeliveryCreatedResponse,
+  DeliveryType,
+} from '@core/services/enum/delivery.types';
+import { MessageService } from 'primeng/api';
+import { Button } from 'primeng/button';
+import { Card } from 'primeng/card';
+import { InputNumber } from 'primeng/inputnumber';
+import { InputText } from 'primeng/inputtext';
+import { Textarea } from 'primeng/textarea';
+import { finalize } from 'rxjs';
+
+@Component({
+  selector: 'app-create-delivery-page',
+  imports: [
+    ReactiveFormsModule,
+    Card,
+    Button,
+    InputText,
+    InputNumber,
+    Textarea,
+  ],
+  templateUrl: './create-delivery-redesign.html',
+  styleUrl: './create-delivery.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CreateDeliveryPage {
+  private readonly fb = inject(FormBuilder);
+  private readonly deliveryService = inject(DeliveryService);
+  private readonly messageService = inject(MessageService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly saving = signal(false);
+  protected readonly latestPricing = signal<DeliveryCreatedResponse | null>(null);
+  protected readonly selectedDeliveryType = signal<DeliveryType>('STANDARD');
+
+  protected readonly deliveryTypeCards: {
+    value: DeliveryType;
+    label: string;
+    eta: string;
+    previewBase: number;
+    disabled?: boolean;
+  }[] = [
+    { value: 'STANDARD', label: 'Standard', eta: '2-4 hours', previewBase: 15 },
+    { value: 'EXPRESS', label: 'Express', eta: '1 hour', previewBase: 25 },
+  ];
+
+  protected readonly previewPricing = computed(() => {
+    const selectedType = this.selectedDeliveryType();
+    const selected = this.deliveryTypeCards.find(
+      (card) => card.value === selectedType,
+    );
+    const baseAmount = selected?.previewBase ?? 15;
+    const feeAmount = 2.5;
+    const taxAmount = Number(((baseAmount + feeAmount) * 0.1).toFixed(2));
+    return {
+      baseAmount,
+      feeAmount,
+      taxAmount,
+      totalAmount: Number((baseAmount + feeAmount + taxAmount).toFixed(2)),
+      currency: 'USD',
+    };
+  });
+
+  protected readonly form = this.fb.nonNullable.group({
+    pickup: this.createAddressGroup(),
+    destination: this.createAddressGroup(),
+    package: this.fb.nonNullable.group({
+      weightKg: this.fb.nonNullable.control(0.01, {
+        validators: [Validators.required, Validators.min(0.01)],
+      }),
+      description: this.fb.nonNullable.control('', {
+        validators: [Validators.required, Validators.maxLength(1000)],
+      }),
+    }),
+    deliveryType: this.fb.nonNullable.control<DeliveryType>('STANDARD', {
+      validators: [Validators.required],
+    }),
+    specialInstructions: this.fb.nonNullable.control('', {
+      validators: [Validators.maxLength(2000)],
+    }),
+  });
+
+  protected onSubmit(): void {
+    if (this.saving()) {
+      return;
+    }
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.saving.set(true);
+    this.deliveryService
+      .create(this.buildPayload())
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.saving.set(false)),
+      )
+      .subscribe({
+        next: (response) => this.handleCreateSuccess(response),
+        error: (error: unknown) => {
+          const mapped = this.deliveryService.applyValidationErrors(
+            this.form,
+            error as HttpErrorResponse,
+          );
+          if (mapped) {
+            this.form.markAllAsTouched();
+            return;
+          }
+          this.form.markAllAsTouched();
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Could not create delivery',
+            detail: 'Please review your data and try again.',
+            life: 5000,
+          });
+        },
+      });
+  }
+
+  protected cancel(): void {
+    void this.router.navigate(['/customer']);
+  }
+
+  protected selectDeliveryType(type: DeliveryType): void {
+    this.form.controls.deliveryType.setValue(type);
+    this.form.controls.deliveryType.markAsTouched();
+    this.selectedDeliveryType.set(type);
+  }
+
+  protected isDeliveryTypeSelected(type: DeliveryType): boolean {
+    return this.form.controls.deliveryType.value === type;
+  }
+
+  protected fieldError(controlPath: string): string | null {
+    const control = this.form.get(controlPath);
+    if (!control?.touched || !control.errors) {
+      return null;
+    }
+
+    if (control.errors['server']) {
+      return String(control.errors['server']);
+    }
+    if (control.errors['required']) {
+      return 'This field is required.';
+    }
+    if (control.errors['email']) {
+      return 'Please enter a valid email.';
+    }
+    if (control.errors['min']) {
+      return `Value must be at least ${control.errors['min'].min}.`;
+    }
+    if (control.errors['max']) {
+      return `Value must be at most ${control.errors['max'].max}.`;
+    }
+    if (control.errors['maxlength']) {
+      return `Maximum length is ${control.errors['maxlength'].requiredLength} characters.`;
+    }
+    if (control.errors['minlength']) {
+      return `Minimum length is ${control.errors['minlength'].requiredLength} characters.`;
+    }
+    if (control.errors['pattern']) {
+      return 'Value format is invalid.';
+    }
+
+    return 'Invalid value.';
+  }
+
+  protected isFieldInvalid(controlPath: string): boolean {
+    const control = this.form.get(controlPath);
+    return Boolean(control && control.invalid && (control.touched || control.dirty));
+  }
+
+  private createAddressGroup() {
+    return this.fb.nonNullable.group({
+      line1: this.fb.nonNullable.control('', {
+        validators: [Validators.required, Validators.maxLength(255)],
+      }),
+      contactName: this.fb.nonNullable.control('', {
+        validators: [Validators.required, Validators.maxLength(255)],
+      }),
+      contactPhone: this.fb.nonNullable.control('', {
+        validators: [Validators.required, Validators.maxLength(64)],
+      }),
+    });
+  }
+
+  private buildPayload(): CreateDeliveryRequest {
+    const raw = this.form.getRawValue();
+    return {
+      pickup: {
+        line1: raw.pickup.line1.trim(),
+        contactName: raw.pickup.contactName.trim(),
+        contactPhone: raw.pickup.contactPhone.trim(),
+      },
+      destination: {
+        line1: raw.destination.line1.trim(),
+        contactName: raw.destination.contactName.trim(),
+        contactPhone: raw.destination.contactPhone.trim(),
+      },
+      package: {
+        weightKg: raw.package.weightKg,
+        description: this.toOptional(raw.package.description),
+      },
+      deliveryType: raw.deliveryType,
+      specialInstructions: this.toOptional(raw.specialInstructions),
+    };
+  }
+
+  private handleCreateSuccess(response: DeliveryCreatedResponse): void {
+    this.latestPricing.set(response);
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Delivery created',
+      detail: `Tracking ${response.trackingCode} | Total ${response.totalAmount} ${response.currency}`,
+      life: 6000,
+    });
+    void this.router.navigate(['/customer']);
+  }
+
+  private toOptional(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  }
+}

--- a/frontend/src/app/features/customer/pages/create-delivery/create-delivery.ts
+++ b/frontend/src/app/features/customer/pages/create-delivery/create-delivery.ts
@@ -46,7 +46,6 @@ export class CreateDeliveryPage {
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly saving = signal(false);
-  protected readonly latestPricing = signal<DeliveryCreatedResponse | null>(null);
   protected readonly selectedDeliveryType = signal<DeliveryType>('STANDARD');
 
   protected readonly deliveryTypeCards: {
@@ -204,6 +203,7 @@ export class CreateDeliveryPage {
 
   private buildPayload(): CreateDeliveryRequest {
     const raw = this.form.getRawValue();
+    const pricing = this.previewPricing();
     return {
       pickup: {
         line1: raw.pickup.line1.trim(),
@@ -217,15 +217,21 @@ export class CreateDeliveryPage {
       },
       package: {
         weightKg: raw.package.weightKg,
-        description: this.toOptional(raw.package.description),
+        description: raw.package.description.trim(),
       },
       deliveryType: raw.deliveryType,
       specialInstructions: this.toOptional(raw.specialInstructions),
+      pricing: {
+        baseAmount: pricing.baseAmount,
+        feeAmount: pricing.feeAmount,
+        taxAmount: pricing.taxAmount,
+        totalAmount: pricing.totalAmount,
+        currency: pricing.currency,
+      },
     };
   }
 
   private handleCreateSuccess(response: DeliveryCreatedResponse): void {
-    this.latestPricing.set(response);
     this.messageService.add({
       severity: 'success',
       summary: 'Delivery created',

--- a/frontend/src/app/features/customer/pages/customer-home/customer-home.html
+++ b/frontend/src/app/features/customer/pages/customer-home/customer-home.html
@@ -43,8 +43,10 @@
               <span class="text-[13px] font-medium text-p-primary">{{ delivery.id }}</span>
             </td>
             <td class="min-w-72 px-4 py-3.5 align-top">
-              <p class="text-[13px] text-p-text-primary">{{ delivery.destination }}</p>
-              <p class="mt-0.5 text-[11px] text-p-text-muted">{{ delivery.destinationHint }}</p>
+              <div class="flex flex-col items-start gap-0.5">
+                <span class="text-[13px] leading-5 text-p-text-primary">{{ delivery.destination }}</span>
+                <span class="text-[11px] leading-4 text-p-text-muted">{{ delivery.destinationHint }}</span>
+              </div>
             </td>
             <td class="w-44 px-4 py-3.5 align-top text-[13px] text-p-text-primary">
               {{ delivery.courierName ?? 'Not assigned' }}

--- a/frontend/src/app/features/customer/pages/customer-home/customer-home.ts
+++ b/frontend/src/app/features/customer/pages/customer-home/customer-home.ts
@@ -71,14 +71,51 @@ export class CustomerHome {
   }
 
   private mapDeliveryRow(delivery: DeliverySummaryDto): CustomerDeliveryRow {
+    const pickup = this.toDisplayPlace(
+      delivery.pickupLine1,
+      'Pickup address',
+    );
+    const destination = this.toDisplayPlace(
+      delivery.destinationLine1,
+      'Destination address',
+    );
+
     return {
       id: this.toDeliveryCode(delivery.id),
-      destination: delivery.pickupCity,
-      destinationHint: `to ${delivery.destinationCity}`,
+      destination,
+      destinationHint: `from ${pickup}`,
       courierName: undefined,
       status: delivery.status,
-      eta: 'N/A',
+      eta: this.toEtaLabel(delivery),
     };
+  }
+
+  private toEtaLabel(delivery: DeliverySummaryDto): string {
+    switch (delivery.status) {
+      case DeliveryStatus.CREATED:
+        return 'Waiting for courier';
+      case DeliveryStatus.ASSIGNED:
+        return 'Courier en route';
+      case DeliveryStatus.PICKED_UP:
+      case DeliveryStatus.IN_TRANSIT:
+        return delivery.deliveryType === 'EXPRESS' ? '1 hour' : '2-4 hours';
+      case DeliveryStatus.DELIVERED:
+        return 'Delivered';
+      case DeliveryStatus.CANCELLED:
+        return 'Cancelled';
+      case DeliveryStatus.FAILED:
+        return 'Delivery issue';
+      default:
+        return 'To be confirmed';
+    }
+  }
+
+  private toDisplayPlace(
+    value: string | null | undefined,
+    fallback: string,
+  ): string {
+    const normalized = value?.trim();
+    return normalized && normalized.length > 0 ? normalized : fallback;
   }
 
   private toDeliveryCode(id: string): string {


### PR DESCRIPTION
This pull request refactors the delivery domain and API to simplify address and package data, and to shift pricing calculation responsibility to the client. The changes remove unused address and package fields, update DTOs and mapping logic accordingly, and introduce a new pricing payload. The delivery summary and list payloads are also updated to better support frontend route rendering.

**API and Domain Model Simplification:**

* Removed unused address fields (`line2`, `city`, `region`, `postalCode`, `country`) from `AddressContact`, related DTOs, and database mappings, leaving only `line1`, `contactName`, and `contactPhone` as required fields. 
* Removed unused package fields (`lengthCm`, `widthCm`, `heightCm`, `fragile`) from the domain model, DTOs, and request validation. The package now only requires `weightKg` and `description`. 

**API Payload and Validation Updates:**

* Updated the delivery creation endpoint to require a new `pricing` object (with `baseAmount`, `feeAmount`, `taxAmount`, `totalAmount`, `currency`) in the request, and to expect the simplified address and package shapes.
* Updated all relevant DTOs and mapping logic to match the new request/response shapes, including renaming `packageDetails` to `packageData`. 

**Delivery List and Summary Improvements:**

* Changed delivery summary/list payloads to include `pickupLine1` and `destinationLine1` instead of city fields, to better support frontend route rendering.

**Documentation:**

* Updated the `README.md` to document the new delivery creation and list payload shapes, clarifying that pricing is now provided by the client and simply validated/persisted by the backend.

**Code Cleanup:**

* Removed unused imports and parameters from the mapper and related classes. 

These changes streamline the delivery API and model, making the backend more maintainable and the API easier for frontend integration.