### PR TITLE
GET /api/v1/deliveries/available + filters (#37)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -138,3 +138,19 @@ List rows include route-friendly address fields in camelCase:
 - `pickupLine1` (route hint, e.g. "from ...")
 
 **Idempotency:** duplicate POSTs create separate deliveries (GitHub #31).
+
+## Courier available deliveries (GET `/api/deliveries/available`)
+
+Courier role only (`ROLE_COURIER`). Returns a paged list of assignable deliveries:
+
+- only `CREATED` rows
+- only unassigned rows (`courier_id IS NULL`)
+- optional filter: `deliveryType=STANDARD|EXPRESS`
+- supports pageable query params (`page`, `size`, `sort`)
+
+Response rows include:
+
+- identity/status: `id`, `status`, `deliveryType`
+- route summary: `pickupLine1`, `destinationLine1`
+- pricing snapshot: `baseAmount`, `feeAmount`, `taxAmount`, `totalAmount`, `currency`
+- placeholders for future matching signals: `distanceKm`, `etaMinutes` (`null` in current implementation)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AvailableDeliveryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/AvailableDeliveryDto.java
@@ -1,0 +1,26 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+/**
+ * Courier-facing row shape for available delivery cards (#37).
+ */
+@Value
+@Builder
+public class AvailableDeliveryDto {
+    String id;
+    String status;
+    String deliveryType;
+    String pickupLine1;
+    String destinationLine1;
+    BigDecimal baseAmount;
+    BigDecimal feeAmount;
+    BigDecimal taxAmount;
+    BigDecimal totalAmount;
+    String currency;
+    BigDecimal distanceKm;
+    Integer etaMinutes;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -1,13 +1,18 @@
 package com.ubb.deliveryhub.delivery.repository;
 
 import com.ubb.deliveryhub.delivery.domain.Delivery;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSpecificationExecutor<Delivery> {
@@ -17,4 +22,17 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
     @EntityGraph(attributePaths = {"customer", "courier"})
     @Query("SELECT d FROM Delivery d WHERE d.id = :id")
     Optional<Delivery> findWithCustomerAndCourierById(@Param("id") UUID id);
+
+    @Query("""
+        SELECT d
+        FROM Delivery d
+        WHERE d.courier IS NULL
+          AND d.status IN :statuses
+          AND (:deliveryType IS NULL OR d.deliveryType = :deliveryType)
+        """)
+    Page<Delivery> findAvailableForCourier(
+        @Param("statuses") Set<DeliveryStatus> statuses,
+        @Param("deliveryType") DeliveryType deliveryType,
+        Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -87,8 +87,6 @@ public final class DeliveryMapper {
             .taxAmount(d.getTaxAmount())
             .totalAmount(d.getTotalAmount())
             .currency(d.getCurrency())
-            .distanceKm(null)
-            .etaMinutes(null)
             .build();
     }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -4,6 +4,7 @@ import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
 import com.ubb.deliveryhub.delivery.domain.dto.AddressContactDto;
 import com.ubb.deliveryhub.delivery.domain.dto.AddressContactRequestDto;
+import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CourierSummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
@@ -69,6 +70,25 @@ public final class DeliveryMapper {
             .currency(d.getCurrency())
             .pickupLine1(pickupLine1)
             .destinationLine1(destinationLine1)
+            .build();
+    }
+
+    public static AvailableDeliveryDto toAvailableDto(Delivery d) {
+        String pickupLine1 = d.getPickup() != null ? d.getPickup().getLine1() : null;
+        String destinationLine1 = d.getDestination() != null ? d.getDestination().getLine1() : null;
+        return AvailableDeliveryDto.builder()
+            .id(d.getId().toString())
+            .status(d.getStatus().name())
+            .deliveryType(d.getDeliveryType().name())
+            .pickupLine1(pickupLine1)
+            .destinationLine1(destinationLine1)
+            .baseAmount(d.getBaseAmount())
+            .feeAmount(d.getFeeAmount())
+            .taxAmount(d.getTaxAmount())
+            .totalAmount(d.getTotalAmount())
+            .currency(d.getCurrency())
+            .distanceKm(null)
+            .etaMinutes(null)
             .build();
     }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -31,10 +31,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +50,7 @@ public class DeliveryService {
     private static final String TRACKING_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final int TRACKING_BODY_LEN = 10;
     private static final int TRACKING_CODE_SAVE_ATTEMPTS = 15;
+    private static final Set<DeliveryStatus> ASSIGNABLE_STATUSES = Set.of(DeliveryStatus.CREATED);
 
     private final DeliveryRepository deliveryRepository;
     private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
@@ -121,15 +120,8 @@ public class DeliveryService {
         }
         assertAllowedSort(pageable.getSort());
         Pageable effective = applyDefaultSort(pageable);
-        Set<DeliveryStatus> assignableStatuses = Arrays.stream(DeliveryStatus.values())
-            .filter(status -> isAssignable(status, null))
-            .collect(Collectors.toUnmodifiableSet());
-        return deliveryRepository.findAvailableForCourier(assignableStatuses, deliveryType, effective)
+        return deliveryRepository.findAvailableForCourier(ASSIGNABLE_STATUSES, deliveryType, effective)
             .map(DeliveryMapper::toAvailableDto);
-    }
-
-    static boolean isAssignable(DeliveryStatus status, UUID assignedCourierId) {
-        return status == DeliveryStatus.CREATED && assignedCourierId == null;
     }
 
     private static UUID principalUserId(Authentication authentication) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -3,7 +3,9 @@ package com.ubb.deliveryhub.delivery.service;
 import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
+import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
@@ -29,8 +31,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,6 +109,27 @@ public class DeliveryService {
         UUID customerId = principalUserId(authentication);
         Specification<Delivery> spec = DeliverySpecifications.forCustomerWithOptionalStatus(customerId, statusFilter);
         return deliveryRepository.findAll(spec, effective).map(DeliveryMapper::toSummaryDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AvailableDeliveryDto> listAvailableForCurrentCourier(
+        Pageable pageable,
+        DeliveryType deliveryType
+    ) {
+        if (!pageable.isPaged()) {
+            throw new InvalidDeliveryPaginationException();
+        }
+        assertAllowedSort(pageable.getSort());
+        Pageable effective = applyDefaultSort(pageable);
+        Set<DeliveryStatus> assignableStatuses = Arrays.stream(DeliveryStatus.values())
+            .filter(status -> isAssignable(status, null))
+            .collect(Collectors.toUnmodifiableSet());
+        return deliveryRepository.findAvailableForCourier(assignableStatuses, deliveryType, effective)
+            .map(DeliveryMapper::toAvailableDto);
+    }
+
+    static boolean isAssignable(DeliveryStatus status, UUID assignedCourierId) {
+        return status == DeliveryStatus.CREATED && assignedCourierId == null;
     }
 
     private static UUID principalUserId(Authentication authentication) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -2,6 +2,8 @@ package com.ubb.deliveryhub.delivery.web;
 
 import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.delivery.domain.DeliveryType;
+import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
@@ -47,6 +49,19 @@ public class DeliveryController {
         @RequestParam(required = false) DeliveryStatus status
     ) {
         return deliveryService.listForCurrentCustomer(authentication, pageable, status);
+    }
+
+    @GetMapping("/available")
+    @PreAuthorize("hasRole('COURIER')")
+    public Page<AvailableDeliveryDto> listAvailableForCurrentCourier(
+        @PageableDefault(
+            size = DeliveryListDefaults.PAGE_SIZE,
+            sort = DeliveryListDefaults.SORT_PROPERTY,
+            direction = Sort.Direction.DESC
+        ) Pageable pageable,
+        @RequestParam(required = false) DeliveryType deliveryType
+    ) {
+        return deliveryService.listAvailableForCurrentCourier(pageable, deliveryType);
     }
 
     @PostMapping


### PR DESCRIPTION
This pull request adds a new API endpoint for couriers to retrieve a paginated list of available deliveries, along with all necessary backend support. The new endpoint returns only deliveries in the `CREATED` state that are unassigned, and supports filtering and sorting. The implementation includes a new DTO, repository query, service method, and controller mapping.

**API and Documentation:**
- Added a new endpoint `GET /api/deliveries/available` for couriers to fetch assignable deliveries, with support for paging, sorting, and optional filtering by delivery type. Updated `README.md` to document the endpoint and its response structure. 

**DTO and Mapping:**
- Introduced `AvailableDeliveryDto` to define the shape of data returned to couriers, including fields for route summary and pricing. Added mapping logic in `DeliveryMapper`. 

**Repository Layer:**
- Added `findAvailableForCourier` query in `DeliveryRepository` to fetch unassigned deliveries in the correct status, with optional type filtering and pagination.

**Service Layer:**
- Implemented `listAvailableForCurrentCourier` in `DeliveryService` to coordinate filtering, sorting, and mapping for the new endpoint, including logic for determining assignable deliveries.

**Controller:**
- Exposed the new endpoint in `DeliveryController`, restricted to users with the courier role.

These changes collectively provide a robust, paginated, and filterable way for couriers to discover available deliveries to accept.