### PR TITLE
POST /api/v1/deliveries/{id}/accept transactional assign (#38)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -154,3 +154,17 @@ Response rows include:
 - route summary: `pickupLine1`, `destinationLine1`
 - pricing snapshot: `baseAmount`, `feeAmount`, `taxAmount`, `totalAmount`, `currency`
 - placeholders for future matching signals: `distanceKm`, `etaMinutes` (`null` in current implementation)
+
+## Courier accept delivery (POST `/api/deliveries/{id}/accept`)
+
+Courier role only (`ROLE_COURIER`). Accept is transactional and concurrency-safe using a pessimistic row lock (`PESSIMISTIC_WRITE`) on the selected delivery:
+
+- acquires lock on delivery row by id
+- re-checks assignable conditions under lock (`status=CREATED`, `courier_id IS NULL`)
+- sets assignment atomically (`courier_id=current courier`, `status=ASSIGNED`)
+- appends `ASSIGNED` entry in `delivery_status_history` in the same transaction
+
+Conflict semantics:
+
+- returns `409 Conflict` with RFC 7807 payload and stable machine code `DELIVERY_TAKEN` when another courier already claimed the delivery or it is no longer assignable
+- returns `404` when delivery id does not exist

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/DeliveryTakenException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/DeliveryTakenException.java
@@ -1,0 +1,13 @@
+package com.ubb.deliveryhub.delivery.domain.exception;
+
+import java.io.Serial;
+
+public class DeliveryTakenException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public DeliveryTakenException() {
+        super("Delivery is no longer available for acceptance");
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -8,9 +8,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -22,6 +24,11 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
     @EntityGraph(attributePaths = {"customer", "courier"})
     @Query("SELECT d FROM Delivery d WHERE d.id = :id")
     Optional<Delivery> findWithCustomerAndCourierById(@Param("id") UUID id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = {"customer", "courier"})
+    @Query("SELECT d FROM Delivery d WHERE d.id = :id")
+    Optional<Delivery> findWithCustomerAndCourierByIdForUpdate(@Param("id") UUID id);
 
     @Query("""
         SELECT d

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -11,6 +11,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryNotFoundException;
+import com.ubb.deliveryhub.delivery.domain.exception.DeliveryTakenException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
@@ -122,6 +123,33 @@ public class DeliveryService {
         Pageable effective = applyDefaultSort(pageable);
         return deliveryRepository.findAvailableForCourier(ASSIGNABLE_STATUSES, deliveryType, effective)
             .map(DeliveryMapper::toAvailableDto);
+    }
+
+    @Transactional
+    public DeliveryDetailDto acceptForCurrentCourier(UUID deliveryId, Authentication authentication) {
+        UUID courierId = principalUserId(authentication);
+        User courier = userRepository.findById(courierId)
+            .orElseThrow(() -> new EntityNotFoundException("User with id %s not found".formatted(courierId)));
+
+        Delivery delivery = deliveryRepository.findWithCustomerAndCourierByIdForUpdate(deliveryId)
+            .orElseThrow(DeliveryNotFoundException::new);
+
+        if (delivery.getCourier() != null || !ASSIGNABLE_STATUSES.contains(delivery.getStatus())) {
+            throw new DeliveryTakenException();
+        }
+
+        delivery.setCourier(courier);
+        delivery.setStatus(DeliveryStatus.ASSIGNED);
+
+        DeliveryStatusHistory historyEntry = new DeliveryStatusHistory();
+        historyEntry.setDelivery(delivery);
+        historyEntry.setStatus(DeliveryStatus.ASSIGNED);
+        historyEntry.setActor(courier);
+        deliveryStatusHistoryRepository.save(historyEntry);
+
+        Delivery saved = deliveryRepository.save(delivery);
+        var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(saved.getId());
+        return DeliveryMapper.toDetailDto(saved, history);
     }
 
     private static UUID principalUserId(Authentication authentication) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -84,4 +84,10 @@ public class DeliveryController {
     public DeliveryDetailDto getById(@PathVariable UUID id, Authentication authentication) {
         return deliveryService.getByIdForCurrentUser(id, authentication);
     }
+
+    @PostMapping("/{id}/accept")
+    @PreAuthorize("hasRole('COURIER')")
+    public DeliveryDetailDto accept(@PathVariable UUID id, Authentication authentication) {
+        return deliveryService.acceptForCurrentCourier(id, authentication);
+    }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
@@ -2,6 +2,7 @@ package com.ubb.deliveryhub.delivery.web;
 
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
+import com.ubb.deliveryhub.delivery.domain.exception.DeliveryTakenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -23,5 +24,12 @@ public class DeliveryExceptionHandler {
     public ResponseEntity<ProblemDetail> handleInvalidDeliveryPagination(InvalidDeliveryPaginationException ex) {
         return ResponseEntity.badRequest()
             .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage()));
+    }
+
+    @ExceptionHandler(DeliveryTakenException.class)
+    public ResponseEntity<ProblemDetail> handleDeliveryTaken(DeliveryTakenException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        pd.setProperty("code", "DELIVERY_TAKEN");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(pd);
     }
 }


### PR DESCRIPTION
This pull request introduces a new endpoint for couriers to accept deliveries in a concurrency-safe way, along with supporting transactional logic, repository changes, and error handling. The implementation ensures only one courier can claim a delivery at a time and provides clear conflict semantics.

**New courier delivery acceptance feature:**

* Added a new POST endpoint `/api/deliveries/{id}/accept` for couriers to accept deliveries, with transactional logic and pessimistic locking to prevent race conditions. The endpoint checks assignable conditions under lock, assigns the courier, updates status, and appends a status history entry atomically. 

**Repository and domain changes for concurrency:**

* Introduced a new repository method `findWithCustomerAndCourierByIdForUpdate` in `DeliveryRepository` using `@Lock(LockModeType.PESSIMISTIC_WRITE)` and `@EntityGraph` to fetch and lock the delivery row for update. 
* Added a custom `DeliveryTakenException` to represent the case where a delivery is no longer available for acceptance. 

**Error handling improvements:**

* Implemented a global exception handler for `DeliveryTakenException` that returns a `409 Conflict` with a stable machine code `DELIVERY_TAKEN` in the response payload, following RFC 7807. 

**Documentation:**

* Updated `backend/README.md` to document the new courier accept delivery endpoint, transactional behavior, and conflict semantics.