### PR TITLE
PATCH /api/v1/deliveries/{id}/status + state machine validation (#40)

### DIFF
--- a/backend/docs/state-machine.md
+++ b/backend/docs/state-machine.md
@@ -1,0 +1,49 @@
+# Delivery status state machine
+
+This document is the single source of truth for allowed status transitions used by backend endpoint `PATCH /api/deliveries/{id}/status`.
+
+## Transition matrix
+
+| Current status | Allowed next statuses |
+| --- | --- |
+| `CREATED` | `ASSIGNED` |
+| `ASSIGNED` | `PICKED_UP` |
+| `PICKED_UP` | `IN_TRANSIT` |
+| `IN_TRANSIT` | `DELIVERED` |
+| `DELIVERED` | _(none, terminal)_ |
+| `CANCELLED` | _(none, terminal)_ |
+| `FAILED` | _(none, terminal)_ |
+
+## Endpoint request forms
+
+Exactly one field is required:
+
+- explicit target:
+
+```json
+{
+  "targetStatus": "IN_TRANSIT"
+}
+```
+
+- action mapped to status:
+
+```json
+{
+  "action": "PICKED_UP"
+}
+```
+
+Supported actions: `PICKED_UP`, `IN_TRANSIT`, `DELIVERED`.
+
+## Authorization and error semantics
+
+- Caller must have role `COURIER` and must be the assigned courier for that delivery.
+- Illegal transitions return `400` with code `INVALID_STATUS_TRANSITION`.
+- Ownership violations return `403` via global access-denied handling.
+- Missing delivery returns `404`.
+
+## Consistency guarantees
+
+- Status update and history append are persisted inside one transaction.
+- A `DeliveryStatusChangedEvent` is published after commit for downstream integrations (tracking/notifications).

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStateMachine.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStateMachine.java
@@ -1,0 +1,39 @@
+package com.ubb.deliveryhub.delivery.domain;
+
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryStatusTransitionException;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class DeliveryStateMachine {
+
+    private final Map<DeliveryStatus, Set<DeliveryStatus>> allowedTransitions;
+
+    public DeliveryStateMachine() {
+        EnumMap<DeliveryStatus, Set<DeliveryStatus>> matrix = new EnumMap<>(DeliveryStatus.class);
+        matrix.put(DeliveryStatus.CREATED, EnumSet.of(DeliveryStatus.ASSIGNED));
+        matrix.put(DeliveryStatus.ASSIGNED, EnumSet.of(DeliveryStatus.PICKED_UP));
+        matrix.put(DeliveryStatus.PICKED_UP, EnumSet.of(DeliveryStatus.IN_TRANSIT));
+        matrix.put(DeliveryStatus.IN_TRANSIT, EnumSet.of(DeliveryStatus.DELIVERED));
+        matrix.put(DeliveryStatus.DELIVERED, EnumSet.noneOf(DeliveryStatus.class));
+        matrix.put(DeliveryStatus.CANCELLED, EnumSet.noneOf(DeliveryStatus.class));
+        matrix.put(DeliveryStatus.FAILED, EnumSet.noneOf(DeliveryStatus.class));
+        this.allowedTransitions = Collections.unmodifiableMap(matrix);
+    }
+
+    public void assertTransitionAllowed(DeliveryStatus from, DeliveryStatus to) {
+        Set<DeliveryStatus> allowedTargets = allowedTargetsFrom(from);
+        if (!allowedTargets.contains(to)) {
+            throw new InvalidDeliveryStatusTransitionException(from, to, allowedTargets);
+        }
+    }
+
+    public Set<DeliveryStatus> allowedTargetsFrom(DeliveryStatus from) {
+        return Set.copyOf(allowedTransitions.getOrDefault(from, Set.of()));
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStateMachine.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStateMachine.java
@@ -33,6 +33,20 @@ public class DeliveryStateMachine {
         }
     }
 
+    public boolean canTransition(DeliveryStatus from, DeliveryStatus to) {
+        return allowedTargetsFrom(from).contains(to);
+    }
+
+    public Set<DeliveryStatus> statusesTransitioningTo(DeliveryStatus targetStatus) {
+        EnumSet<DeliveryStatus> result = EnumSet.noneOf(DeliveryStatus.class);
+        for (Map.Entry<DeliveryStatus, Set<DeliveryStatus>> entry : allowedTransitions.entrySet()) {
+            if (entry.getValue().contains(targetStatus)) {
+                result.add(entry.getKey());
+            }
+        }
+        return Set.copyOf(result);
+    }
+
     public Set<DeliveryStatus> allowedTargetsFrom(DeliveryStatus from) {
         return Set.copyOf(allowedTransitions.getOrDefault(from, Set.of()));
     }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryStatusAction.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryStatusAction.java
@@ -1,0 +1,19 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+public enum DeliveryStatusAction {
+    PICKED_UP(DeliveryStatus.PICKED_UP),
+    IN_TRANSIT(DeliveryStatus.IN_TRANSIT),
+    DELIVERED(DeliveryStatus.DELIVERED);
+
+    private final DeliveryStatus targetStatus;
+
+    DeliveryStatusAction(DeliveryStatus targetStatus) {
+        this.targetStatus = targetStatus;
+    }
+
+    public DeliveryStatus targetStatus() {
+        return targetStatus;
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/UpdateDeliveryStatusRequest.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/UpdateDeliveryStatusRequest.java
@@ -13,7 +13,7 @@ public class UpdateDeliveryStatusRequest {
     private DeliveryStatusAction action;
 
     @AssertTrue(message = "Provide exactly one of targetStatus or action")
-    public boolean isExactlyOneStatusInputProvided() {
+    public boolean isValid() {
         return (targetStatus == null) != (action == null);
     }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/UpdateDeliveryStatusRequest.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/UpdateDeliveryStatusRequest.java
@@ -1,0 +1,26 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateDeliveryStatusRequest {
+
+    private DeliveryStatus targetStatus;
+    private DeliveryStatusAction action;
+
+    @AssertTrue(message = "Provide exactly one of targetStatus or action")
+    public boolean isExactlyOneStatusInputProvided() {
+        return (targetStatus == null) != (action == null);
+    }
+
+    public DeliveryStatus resolveTargetStatus() {
+        if (targetStatus != null) {
+            return targetStatus;
+        }
+        return action.targetStatus();
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliveryStatusTransitionException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/exception/InvalidDeliveryStatusTransitionException.java
@@ -1,0 +1,25 @@
+package com.ubb.deliveryhub.delivery.domain.exception;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+public class InvalidDeliveryStatusTransitionException extends RuntimeException {
+
+    private final DeliveryStatus fromStatus;
+    private final DeliveryStatus toStatus;
+    private final Set<DeliveryStatus> allowedTargets;
+
+    public InvalidDeliveryStatusTransitionException(
+        DeliveryStatus fromStatus,
+        DeliveryStatus toStatus,
+        Set<DeliveryStatus> allowedTargets
+    ) {
+        super("Invalid status transition from %s to %s".formatted(fromStatus, toStatus));
+        this.fromStatus = fromStatus;
+        this.toStatus = toStatus;
+        this.allowedTargets = Set.copyOf(allowedTargets);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/events/DeliveryStatusChangedEvent.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/events/DeliveryStatusChangedEvent.java
@@ -1,0 +1,13 @@
+package com.ubb.deliveryhub.delivery.events;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+import java.util.UUID;
+
+public record DeliveryStatusChangedEvent(
+    UUID deliveryId,
+    DeliveryStatus fromStatus,
+    DeliveryStatus toStatus,
+    UUID actorId
+) {
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryAuthorization.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryAuthorization.java
@@ -50,6 +50,13 @@ public class DeliveryAuthorization {
         throw new AccessDeniedException("Access denied");
     }
 
+    public void assertAssignedCourier(Delivery delivery, UUID principalId) {
+        User assigned = delivery.getCourier();
+        if (assigned == null || !assigned.getId().equals(principalId)) {
+            throw new AccessDeniedException("Access denied");
+        }
+    }
+
     private boolean hasRole(Authentication authentication, UserRole role) {
         String expected = ROLE_PREFIX + role.name();
         for (GrantedAuthority a : authentication.getAuthorities()) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -57,7 +57,6 @@ public class DeliveryService {
     private static final String TRACKING_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final int TRACKING_BODY_LEN = 10;
     private static final int TRACKING_CODE_SAVE_ATTEMPTS = 15;
-    private static final Set<DeliveryStatus> ASSIGNABLE_STATUSES = Set.of(DeliveryStatus.CREATED);
 
     private final DeliveryRepository deliveryRepository;
     private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
@@ -129,7 +128,8 @@ public class DeliveryService {
         }
         assertAllowedSort(pageable.getSort());
         Pageable effective = applyDefaultSort(pageable);
-        return deliveryRepository.findAvailableForCourier(ASSIGNABLE_STATUSES, deliveryType, effective)
+        Set<DeliveryStatus> assignableStatuses = deliveryStateMachine.statusesTransitioningTo(DeliveryStatus.ASSIGNED);
+        return deliveryRepository.findAvailableForCourier(assignableStatuses, deliveryType, effective)
             .map(DeliveryMapper::toAvailableDto);
     }
 
@@ -142,7 +142,8 @@ public class DeliveryService {
         Delivery delivery = deliveryRepository.findWithCustomerAndCourierByIdForUpdate(deliveryId)
             .orElseThrow(DeliveryNotFoundException::new);
 
-        if (delivery.getCourier() != null || !ASSIGNABLE_STATUSES.contains(delivery.getStatus())) {
+        if (delivery.getCourier() != null
+            || !deliveryStateMachine.canTransition(delivery.getStatus(), DeliveryStatus.ASSIGNED)) {
             throw new DeliveryTakenException();
         }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -2,18 +2,21 @@ package com.ubb.deliveryhub.delivery.service;
 
 import com.ubb.deliveryhub.delivery.DeliveryListDefaults;
 import com.ubb.deliveryhub.delivery.domain.Delivery;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStateMachine;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
-import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
+import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.UpdateDeliveryStatusRequest;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryNotFoundException;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryTakenException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
+import com.ubb.deliveryhub.delivery.events.DeliveryStatusChangedEvent;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
 import com.ubb.deliveryhub.delivery.repository.DeliverySpecifications;
 import com.ubb.deliveryhub.delivery.repository.DeliveryStatusHistoryRepository;
@@ -28,8 +31,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.core.Authentication;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.security.SecureRandom;
 import java.util.Set;
@@ -57,6 +63,8 @@ public class DeliveryService {
     private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
     private final UserRepository userRepository;
     private final DeliveryAuthorization deliveryAuthorization;
+    private final DeliveryStateMachine deliveryStateMachine;
+    private final ApplicationEventPublisher eventPublisher;
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Transactional
@@ -152,6 +160,36 @@ public class DeliveryService {
         return DeliveryMapper.toDetailDto(saved, history);
     }
 
+    @Transactional
+    public DeliveryDetailDto updateStatusForCurrentCourier(
+        UUID deliveryId,
+        Authentication authentication,
+        UpdateDeliveryStatusRequest request
+    ) {
+        UUID courierId = principalUserId(authentication);
+        Delivery delivery = deliveryRepository.findWithCustomerAndCourierByIdForUpdate(deliveryId)
+            .orElseThrow(DeliveryNotFoundException::new);
+
+        deliveryAuthorization.assertAssignedCourier(delivery, courierId);
+
+        DeliveryStatus fromStatus = delivery.getStatus();
+        DeliveryStatus targetStatus = request.resolveTargetStatus();
+        deliveryStateMachine.assertTransitionAllowed(fromStatus, targetStatus);
+
+        delivery.setStatus(targetStatus);
+
+        DeliveryStatusHistory historyEntry = new DeliveryStatusHistory();
+        historyEntry.setDelivery(delivery);
+        historyEntry.setStatus(targetStatus);
+        historyEntry.setActor(delivery.getCourier());
+        deliveryStatusHistoryRepository.save(historyEntry);
+
+        Delivery saved = deliveryRepository.save(delivery);
+        publishAfterCommit(saved.getId(), fromStatus, targetStatus, courierId);
+        var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(saved.getId());
+        return DeliveryMapper.toDetailDto(saved, history);
+    }
+
     private static UUID principalUserId(Authentication authentication) {
         return UUID.fromString(authentication.getName());
     }
@@ -184,5 +222,19 @@ public class DeliveryService {
             sb.append(TRACKING_ALPHABET.charAt(secureRandom.nextInt(TRACKING_ALPHABET.length())));
         }
         return sb.toString();
+    }
+
+    private void publishAfterCommit(
+        UUID deliveryId,
+        DeliveryStatus fromStatus,
+        DeliveryStatus toStatus,
+        UUID actorId
+    ) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                eventPublisher.publishEvent(new DeliveryStatusChangedEvent(deliveryId, fromStatus, toStatus, actorId));
+            }
+        });
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -8,6 +8,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.UpdateDeliveryStatusRequest;
 import com.ubb.deliveryhub.delivery.service.DeliveryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -89,5 +91,15 @@ public class DeliveryController {
     @PreAuthorize("hasRole('COURIER')")
     public DeliveryDetailDto accept(@PathVariable UUID id, Authentication authentication) {
         return deliveryService.acceptForCurrentCourier(id, authentication);
+    }
+
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('COURIER')")
+    public DeliveryDetailDto updateStatus(
+        @PathVariable UUID id,
+        Authentication authentication,
+        @Valid @RequestBody UpdateDeliveryStatusRequest request
+    ) {
+        return deliveryService.updateStatusForCurrentCourier(id, authentication, request);
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ubb.deliveryhub.delivery.web;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryPaginationException;
 import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliverySortException;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryTakenException;
+import com.ubb.deliveryhub.delivery.domain.exception.InvalidDeliveryStatusTransitionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +32,15 @@ public class DeliveryExceptionHandler {
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
         pd.setProperty("code", "DELIVERY_TAKEN");
         return ResponseEntity.status(HttpStatus.CONFLICT).body(pd);
+    }
+
+    @ExceptionHandler(InvalidDeliveryStatusTransitionException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidStatusTransition(InvalidDeliveryStatusTransitionException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setProperty("code", "INVALID_STATUS_TRANSITION");
+        pd.setProperty("fromStatus", ex.getFromStatus());
+        pd.setProperty("toStatus", ex.getToStatus());
+        pd.setProperty("allowedTargets", ex.getAllowedTargets());
+        return ResponseEntity.badRequest().body(pd);
     }
 }


### PR DESCRIPTION
This pull request introduces a robust and explicit state machine for delivery status transitions, ensuring that only valid status changes are allowed and providing clear error handling and documentation. It adds a new endpoint for couriers to update delivery status, enforces authorization, and emits domain events for downstream integrations. The most important changes are grouped below:

**Delivery Status State Machine Implementation**

* Introduced a `DeliveryStateMachine` component that defines and enforces allowed delivery status transitions, throwing a specific exception (`InvalidDeliveryStatusTransitionException`) on invalid transitions. 
* Added a new request DTO (`UpdateDeliveryStatusRequest`) and action enum (`DeliveryStatusAction`) to support updating status via either a target status or a mapped action. 

**API and Authorization Enhancements**

* Added a new endpoint `PATCH /api/deliveries/{id}/status` to `DeliveryController`, allowing assigned couriers to update the status of a delivery, with strict validation and authorization checks. 
* Improved error handling: returns a `400` with a specific code for invalid transitions, and `403` for authorization violations. 

**Event Publishing and Consistency**

* Ensured that status updates and history entries are persisted transactionally, and a `DeliveryStatusChangedEvent` is published after commit for downstream consumers (e.g., tracking/notifications). 

**Documentation**

* Added a comprehensive `state-machine.md` document describing the allowed transitions, API contract, authorization, error semantics, and consistency guarantees for delivery status updates.