### PR TITLE
GET /api/v1/deliveries/{id}/status polling endpoint (UC1 baseline) (#44)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -168,3 +168,13 @@ Conflict semantics:
 
 - returns `409 Conflict` with RFC 7807 payload and stable machine code `DELIVERY_TAKEN` when another courier already claimed the delivery or it is no longer assignable
 - returns `404` when delivery id does not exist
+
+## Delivery status snapshot (GET `/api/deliveries/{id}/status`)
+
+Compact polling endpoint for tracking and WS fallback:
+
+- response fields: `status`, `etaMinutes`, `updatedAt`, `progressPercent`
+- ownership semantics are identical to `GET /api/deliveries/{id}`
+- includes `ETag` so clients can use `If-None-Match` and receive `304 Not Modified` when unchanged
+
+Polling methodology and curl baseline loop are documented in `docs/polling-tracking-baseline.md`.

--- a/backend/docs/polling-tracking-baseline.md
+++ b/backend/docs/polling-tracking-baseline.md
@@ -1,0 +1,57 @@
+# Polling tracking baseline (GH-44)
+
+This document defines the REST polling baseline used to compare against WebSocket tracking (GH-43) in UC1.
+
+## Endpoint contract
+
+- Method/path: `GET /api/deliveries/{id}/status`
+- Auth: JWT Bearer, same visibility policy as `GET /api/deliveries/{id}`
+- Response payload:
+  - `status` (`CREATED|ASSIGNED|PICKED_UP|IN_TRANSIT|DELIVERED|CANCELLED|FAILED`)
+  - `etaMinutes` (nullable; currently `null`)
+  - `updatedAt` (ISO-8601 UTC timestamp)
+  - `progressPercent` (nullable, derived cheaply from status)
+
+The payload is intentionally compact for high-frequency requests.
+
+## Authorization and error semantics
+
+The endpoint reuses delivery ownership policy from #32:
+
+- owned customer / assigned courier / admin -> `200`
+- unrelated authenticated user -> `403`
+- missing delivery id -> `404`
+
+Unknown ETA is represented as `null` (not as `0`).
+
+## Cache hints for polling
+
+Responses include an `ETag` based on delivery status and `updatedAt`. Clients may send `If-None-Match` to reduce payload transfer:
+
+- no status change -> `304 Not Modified`
+- status changed -> `200` with the new snapshot body
+
+## Suggested polling intervals
+
+- Demo and local comparisons: every `2s` to `5s`
+- Production-like baseline: start around `10s` and lower only when UX requires it
+
+Use jitter (for example +/- 300ms) on multi-client scenarios to avoid synchronized spikes.
+
+## Curl loop example (baseline experiment)
+
+```bash
+TOKEN="<jwt>"
+DELIVERY_ID="<delivery-uuid>"
+
+while true; do
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+  curl -sS "http://localhost:8080/api/deliveries/${DELIVERY_ID}/status" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/json"
+  echo
+  sleep 3
+done
+```
+
+For bandwidth-focused runs, persist and resend `ETag` via `If-None-Match` between calls.

--- a/backend/docs/websocket-tracking.md
+++ b/backend/docs/websocket-tracking.md
@@ -60,7 +60,7 @@ Events are published to `/topic/deliveries/{deliveryId}/tracking` after successf
 - Client reconnect strategy:
   - exponential backoff (`1s`, `2s`, `4s`, ... up to `30s`),
   - re-subscribe after reconnect,
-  - fallback to polling (`GET /api/deliveries/{id}` and read `status`) while socket is down.
+  - fallback to polling (`GET /api/deliveries/{id}/status`) while socket is down.
 - Reverse proxy/Nginx:
   - enable HTTP upgrade headers for `/api/ws-tracking`,
   - use sticky sessions if running multiple API nodes with in-memory broker.

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryStatusSnapshotDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/DeliveryStatusSnapshotDto.java
@@ -1,0 +1,18 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+/**
+ * Compact delivery status payload for high-frequency polling (#44).
+ */
+@Value
+@Builder
+public class DeliveryStatusSnapshotDto {
+    String status;
+    Integer etaMinutes;
+    Instant updatedAt;
+    Integer progressPercent;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -30,8 +30,9 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
           d.status AS status,
           d.updatedAt AS updatedAt,
           d.customer.id AS customerId,
-          d.courier.id AS courierId
+          c.id AS courierId
         FROM Delivery d
+        LEFT JOIN d.courier c
         WHERE d.id = :id
         """)
     Optional<DeliveryStatusSnapshotView> findStatusSnapshotById(@Param("id") UUID id);

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -25,6 +25,17 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
     @Query("SELECT d FROM Delivery d WHERE d.id = :id")
     Optional<Delivery> findWithCustomerAndCourierById(@Param("id") UUID id);
 
+    @Query("""
+        SELECT
+          d.status AS status,
+          d.updatedAt AS updatedAt,
+          d.customer.id AS customerId,
+          d.courier.id AS courierId
+        FROM Delivery d
+        WHERE d.id = :id
+        """)
+    Optional<DeliveryStatusSnapshotView> findStatusSnapshotById(@Param("id") UUID id);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @EntityGraph(attributePaths = {"customer", "courier"})
     @Query("SELECT d FROM Delivery d WHERE d.id = :id")

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusSnapshotView.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusSnapshotView.java
@@ -1,0 +1,19 @@
+package com.ubb.deliveryhub.delivery.repository;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Read projection used by polling status endpoint to avoid loading full delivery aggregate.
+ */
+public interface DeliveryStatusSnapshotView {
+    DeliveryStatus getStatus();
+
+    Instant getUpdatedAt();
+
+    UUID getCustomerId();
+
+    UUID getCourierId();
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryAuthorization.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryAuthorization.java
@@ -2,7 +2,6 @@ package com.ubb.deliveryhub.delivery.service;
 
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
-import com.ubb.deliveryhub.identity.domain.User;
 import com.ubb.deliveryhub.identity.domain.embedded.UserRole;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -22,6 +21,16 @@ public class DeliveryAuthorization {
     private static final String ROLE_PREFIX = "ROLE_";
 
     public void assertCanView(Delivery delivery, Authentication authentication) {
+        UUID courierId = delivery.getCourier() != null ? delivery.getCourier().getId() : null;
+        assertCanView(delivery.getCustomer().getId(), courierId, delivery.getStatus(), authentication);
+    }
+
+    public void assertCanView(
+        UUID customerId,
+        UUID courierId,
+        DeliveryStatus status,
+        Authentication authentication
+    ) {
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new AccessDeniedException("Access denied");
         }
@@ -31,18 +40,17 @@ public class DeliveryAuthorization {
             return;
         }
         if (hasRole(authentication, UserRole.CUSTOMER)) {
-            if (delivery.getCustomer().getId().equals(principalId)) {
+            if (customerId.equals(principalId)) {
                 return;
             }
             throw new AccessDeniedException("Access denied");
         }
         if (hasRole(authentication, UserRole.COURIER)) {
-            User assigned = delivery.getCourier();
-            if (assigned != null && assigned.getId().equals(principalId)) {
+            if (courierId != null && courierId.equals(principalId)) {
                 return;
             }
             // Allow couriers to open details for currently available requests.
-            if (assigned == null && delivery.getStatus() == DeliveryStatus.CREATED) {
+            if (courierId == null && status == DeliveryStatus.CREATED) {
                 return;
             }
             throw new AccessDeniedException("Access denied");
@@ -51,8 +59,8 @@ public class DeliveryAuthorization {
     }
 
     public void assertAssignedCourier(Delivery delivery, UUID principalId) {
-        User assigned = delivery.getCourier();
-        if (assigned == null || !assigned.getId().equals(principalId)) {
+        UUID assignedCourierId = delivery.getCourier() != null ? delivery.getCourier().getId() : null;
+        if (assignedCourierId == null || !assignedCourierId.equals(principalId)) {
             throw new AccessDeniedException("Access denied");
         }
     }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryMapper.java
@@ -9,6 +9,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.CourierSummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliveryStatusSnapshotDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.PackageRequestDto;
 import com.ubb.deliveryhub.delivery.domain.dto.TimelineEntryDto;
@@ -17,6 +18,7 @@ import com.ubb.deliveryhub.identity.domain.User;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.List;
 
 public final class DeliveryMapper {
@@ -138,6 +140,20 @@ public final class DeliveryMapper {
             .updatedAt(d.getUpdatedAt())
             .courier(toCourierSummary(d.getCourier()))
             .timeline(timeline)
+            .build();
+    }
+
+    public static DeliveryStatusSnapshotDto toStatusSnapshotDto(
+        String status,
+        Integer etaMinutes,
+        Instant updatedAt,
+        Integer progressPercent
+    ) {
+        return DeliveryStatusSnapshotDto.builder()
+            .status(status)
+            .etaMinutes(etaMinutes)
+            .updatedAt(updatedAt)
+            .progressPercent(progressPercent)
             .build();
     }
 

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -11,6 +11,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliveryStatusSnapshotDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.UpdateDeliveryStatusRequest;
 import com.ubb.deliveryhub.delivery.domain.exception.DeliveryNotFoundException;
@@ -106,6 +107,24 @@ public class DeliveryService {
         deliveryAuthorization.assertCanView(delivery, authentication);
         var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(id);
         return DeliveryMapper.toDetailDto(delivery, history);
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryStatusSnapshotDto getStatusSnapshotForCurrentUser(UUID id, Authentication authentication) {
+        var snapshot = deliveryRepository.findStatusSnapshotById(id)
+            .orElseThrow(DeliveryNotFoundException::new);
+        deliveryAuthorization.assertCanView(
+            snapshot.getCustomerId(),
+            snapshot.getCourierId(),
+            snapshot.getStatus(),
+            authentication
+        );
+        return DeliveryMapper.toStatusSnapshotDto(
+            snapshot.getStatus().name(),
+            null,
+            snapshot.getUpdatedAt(),
+            DeliveryTrackingProgress.fromStatus(snapshot.getStatus())
+        );
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryTrackingProgress.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryTrackingProgress.java
@@ -1,0 +1,23 @@
+package com.ubb.deliveryhub.delivery.service;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+/**
+ * Shared progress heuristic used by tracking payloads (polling and WebSocket).
+ */
+public final class DeliveryTrackingProgress {
+
+    private DeliveryTrackingProgress() {
+    }
+
+    public static Integer fromStatus(DeliveryStatus status) {
+        return switch (status) {
+            case CREATED -> 0;
+            case ASSIGNED -> 25;
+            case PICKED_UP -> 50;
+            case IN_TRANSIT -> 75;
+            case DELIVERED -> 100;
+            case CANCELLED, FAILED -> null;
+        };
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -7,6 +7,7 @@ import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
+import com.ubb.deliveryhub.delivery.domain.dto.DeliveryStatusSnapshotDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliverySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.UpdateDeliveryStatusRequest;
 import com.ubb.deliveryhub.delivery.service.DeliveryService;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -99,6 +102,21 @@ public class DeliveryController {
     @PreAuthorize("hasAnyRole('CUSTOMER','COURIER','ADMIN')")
     public DeliveryDetailDto getById(@PathVariable UUID id, Authentication authentication) {
         return deliveryService.getByIdForCurrentUser(id, authentication);
+    }
+
+    @GetMapping("/{id}/status")
+    @PreAuthorize("hasAnyRole('CUSTOMER','COURIER','ADMIN')")
+    public ResponseEntity<DeliveryStatusSnapshotDto> getStatusSnapshot(
+        @PathVariable UUID id,
+        Authentication authentication,
+        WebRequest webRequest
+    ) {
+        DeliveryStatusSnapshotDto snapshot = deliveryService.getStatusSnapshotForCurrentUser(id, authentication);
+        String etag = "\"%s-%d\"".formatted(snapshot.getStatus(), snapshot.getUpdatedAt().toEpochMilli());
+        if (webRequest.checkNotModified(etag)) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(etag).build();
+        }
+        return ResponseEntity.ok().eTag(etag).body(snapshot);
     }
 
     @PostMapping("/{id}/accept")

--- a/backend/src/main/java/com/ubb/deliveryhub/tracking/service/DeliveryStatusChangedTrackingListener.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/tracking/service/DeliveryStatusChangedTrackingListener.java
@@ -1,7 +1,7 @@
 package com.ubb.deliveryhub.tracking.service;
 
-import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.events.DeliveryStatusChangedEvent;
+import com.ubb.deliveryhub.delivery.service.DeliveryTrackingProgress;
 import com.ubb.deliveryhub.tracking.api.dto.TrackingStatusEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -23,19 +23,8 @@ public class DeliveryStatusChangedTrackingListener {
             event.toStatus(),
             event.updatedAt(),
             null,
-            progressPercent(event.toStatus())
+            DeliveryTrackingProgress.fromStatus(event.toStatus())
         );
         trackingEventPublisher.publish(payload);
-    }
-
-    private static Integer progressPercent(DeliveryStatus status) {
-        return switch (status) {
-            case CREATED -> 0;
-            case ASSIGNED -> 25;
-            case PICKED_UP -> 50;
-            case IN_TRANSIT -> 75;
-            case DELIVERED -> 100;
-            case CANCELLED, FAILED -> null;
-        };
     }
 }


### PR DESCRIPTION
This pull request introduces a new compact polling endpoint for tracking delivery status, providing an efficient REST alternative and fallback to WebSocket-based tracking. The main changes include the implementation of the `/api/deliveries/{id}/status` endpoint, supporting DTOs, authorization logic, and documentation for polling methodology and cache hints. Additionally, code is refactored to share progress calculation logic and ensure efficient data access.

**New delivery status polling endpoint:**
- Added `GET /api/deliveries/{id}/status` endpoint in `DeliveryController`, returning a compact payload (`status`, `etaMinutes`, `updatedAt`, `progressPercent`) with ETag support for efficient polling and 304 responses when unchanged.
- Implemented `DeliveryStatusSnapshotDto` and supporting repository projection (`DeliveryStatusSnapshotView`) to avoid loading the full delivery entity, improving performance for high-frequency polling. 
- Added `DeliveryTrackingProgress` utility to centralize progress percentage calculation from status, used by both polling and WebSocket tracking. 

**Authorization and service logic:**
- Extended `DeliveryAuthorization` to allow permission checks using just customer/courier IDs and status, supporting the new polling endpoint without loading the full delivery object. 
- Added mapping logic in `DeliveryMapper` and service method in `DeliveryService` to build and return the status snapshot DTO. 

**Documentation and developer guidance:**
- Updated `README.md` and added `docs/polling-tracking-baseline.md` to document the new polling endpoint, its contract, error semantics, caching, and recommended polling intervals, including a curl example. 
- Updated WebSocket tracking documentation to reference the new polling endpoint as the recommended fallback.