### PR TITLE
notifications table + list + mark read APIs (#46)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -178,3 +178,13 @@ Compact polling endpoint for tracking and WS fallback:
 - includes `ETag` so clients can use `If-None-Match` and receive `304 Not Modified` when unchanged
 
 Polling methodology and curl baseline loop are documented in `docs/polling-tracking-baseline.md`.
+
+## Notifications API (`#46`)
+
+Customer notifications persistence and read-state endpoints are available with strict user scoping (no client-provided `userId`):
+
+- `GET /api/notifications` with `page`, `size`, `sort`, `unreadOnly`, `type`
+- `PATCH /api/notifications/{id}/read` for idempotent mark-read
+- `PATCH /api/notifications/read-all` returning `{ "updatedCount": <number> }`
+
+Full contract and examples are documented in `docs/notifications-api.md`.

--- a/backend/docs/notifications-api.md
+++ b/backend/docs/notifications-api.md
@@ -1,0 +1,93 @@
+# Notifications API (`#46`)
+
+Base path: `/api`
+
+Endpoints are exposed under `/notifications` only.
+
+## Notification DTO contract
+
+Each list item contains:
+
+- `id`
+- `type`
+- `category`
+- `title`
+- `message`
+- `deliveryId` (nullable)
+- `createdAt`
+- `read` (`true` when `readAt` is present)
+- `readAt` (nullable)
+
+`payload_json` is persistence-only and not part of the API response contract.
+
+## Types dictionary
+
+Stable values used by emitters (`#47`) and UI icon mapping (`#48`):
+
+- `DELIVERY_ASSIGNED`
+- `STATUS_UPDATED`
+- `EXCEPTION_REPORTED`
+- `DELIVERY_CREATED`
+- `DELIVERY_CANCELLED`
+- `SYSTEM_ANNOUNCEMENT`
+
+Categories:
+
+- `DELIVERY`
+- `EXCEPTION`
+- `SYSTEM`
+- `ADMIN`
+
+## `GET /notifications`
+
+Returns paginated notifications for the authenticated customer only.
+
+Query parameters:
+
+- `page`, `size`, `sort` (Spring pageable)
+- `unreadOnly` (optional boolean)
+- `type` (optional enum value from above)
+
+Default sort is `createdAt,desc`.
+
+Example:
+
+```bash
+curl -s -H "Authorization: Bearer <token>" \
+  "http://localhost:8080/api/notifications?unreadOnly=true&type=STATUS_UPDATED&page=0&size=20"
+```
+
+## `PATCH /notifications/{id}/read`
+
+Marks one notification as read for the authenticated customer.
+
+- idempotent: already-read rows still return success
+- ownership-safe: rows outside the current user scope return `404`
+
+Example:
+
+```bash
+curl -i -X PATCH -H "Authorization: Bearer <token>" \
+  "http://localhost:8080/api/notifications/2e4d9268-f4d6-4f09-9fd6-65e4f48aafaa/read"
+```
+
+Expected success status: `204 No Content`.
+
+## `PATCH /notifications/read-all`
+
+Marks all unread notifications as read for the authenticated customer and returns an update count.
+
+Example:
+
+```bash
+curl -s -X PATCH -H "Authorization: Bearer <token>" \
+  "http://localhost:8080/api/notifications/read-all"
+```
+
+Example response:
+
+```json
+{
+  "updatedCount": 3
+}
+```

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/NotificationListDefaults.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/NotificationListDefaults.java
@@ -1,0 +1,14 @@
+package com.ubb.deliveryhub.notification;
+
+/**
+ * Defaults for {@code GET /notifications}; keep {@link #PAGE_SIZE} aligned with
+ * {@code spring.data.web.pageable.default-page-size} in {@code application.properties}.
+ */
+public final class NotificationListDefaults {
+
+    public static final int PAGE_SIZE = 20;
+    public static final String SORT_PROPERTY = "createdAt";
+
+    private NotificationListDefaults() {
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
@@ -1,0 +1,88 @@
+package com.ubb.deliveryhub.notification.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ubb.deliveryhub.delivery.domain.Delivery;
+import com.ubb.deliveryhub.identity.domain.User;
+import com.ubb.deliveryhub.notification.domain.id.NotificationId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+    name = NotificationId.TABLE_NAME,
+    indexes = {
+        @Index(name = NotificationId.IDX_USER_CREATED_AT_DESC, columnList = NotificationId.USER_ID + "," + NotificationId.CREATED_AT),
+        @Index(name = NotificationId.IDX_USER_READ_AT, columnList = NotificationId.USER_ID + "," + NotificationId.READ_AT)
+    }
+)
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @EqualsAndHashCode.Include
+    @ToString.Include
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = NotificationId.USER_ID, nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = NotificationId.DELIVERY_ID)
+    private Delivery delivery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = NotificationId.TYPE, nullable = false, length = 64)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = NotificationId.CATEGORY, nullable = false, length = 32)
+    private NotificationCategory category;
+
+    @Column(name = NotificationId.TITLE, nullable = false, length = 255)
+    private String title;
+
+    @Column(name = NotificationId.MESSAGE, nullable = false, length = 2000)
+    private String message;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = NotificationId.PAYLOAD_JSON)
+    private JsonNode payloadJson;
+
+    @Column(name = NotificationId.CREATED_AT, nullable = false)
+    private Instant createdAt;
+
+    @Column(name = NotificationId.READ_AT)
+    private Instant readAt;
+
+    @PrePersist
+    private void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/NotificationCategory.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/NotificationCategory.java
@@ -1,0 +1,8 @@
+package com.ubb.deliveryhub.notification.domain;
+
+public enum NotificationCategory {
+    DELIVERY,
+    EXCEPTION,
+    SYSTEM,
+    ADMIN
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/NotificationType.java
@@ -1,0 +1,10 @@
+package com.ubb.deliveryhub.notification.domain;
+
+public enum NotificationType {
+    DELIVERY_ASSIGNED,
+    STATUS_UPDATED,
+    EXCEPTION_REPORTED,
+    DELIVERY_CREATED,
+    DELIVERY_CANCELLED,
+    SYSTEM_ANNOUNCEMENT
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/dto/MarkAllReadResponse.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/dto/MarkAllReadResponse.java
@@ -1,0 +1,10 @@
+package com.ubb.deliveryhub.notification.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class MarkAllReadResponse {
+    int updatedCount;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/dto/NotificationDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/dto/NotificationDto.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.notification.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class NotificationDto {
+    String id;
+    String type;
+    String category;
+    String title;
+    String message;
+    String deliveryId;
+    Instant createdAt;
+    boolean read;
+    Instant readAt;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/exception/InvalidNotificationSortException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/exception/InvalidNotificationSortException.java
@@ -1,0 +1,41 @@
+package com.ubb.deliveryhub.notification.domain.exception;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+public class InvalidNotificationSortException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String invalidProperty;
+    private final List<String> allowedProperties;
+
+    public InvalidNotificationSortException(String invalidProperty, Collection<String> allowedProperties) {
+        super(buildDetail(invalidProperty, allowedProperties));
+        this.invalidProperty = invalidProperty;
+        this.allowedProperties = sortedCopy(allowedProperties);
+    }
+
+    public String getInvalidProperty() {
+        return invalidProperty;
+    }
+
+    public List<String> getAllowedProperties() {
+        return allowedProperties;
+    }
+
+    private static String buildDetail(String invalidProperty, Collection<String> allowedProperties) {
+        return "Invalid sort property: %s. Allowed: %s"
+            .formatted(invalidProperty, String.join(", ", sortedCopy(allowedProperties)));
+    }
+
+    private static List<String> sortedCopy(Collection<String> allowedProperties) {
+        List<String> copy = new ArrayList<>(allowedProperties);
+        copy.sort(Comparator.naturalOrder());
+        return List.copyOf(copy);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/exception/NotificationNotFoundException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/exception/NotificationNotFoundException.java
@@ -1,0 +1,15 @@
+package com.ubb.deliveryhub.notification.domain.exception;
+
+import com.ubb.deliveryhub.identity.domain.exception.EntityNotFoundException;
+
+import java.io.Serial;
+
+public class NotificationNotFoundException extends EntityNotFoundException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public NotificationNotFoundException() {
+        super("Notification not found");
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/id/NotificationId.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/id/NotificationId.java
@@ -1,0 +1,23 @@
+package com.ubb.deliveryhub.notification.domain.id;
+
+public final class NotificationId {
+
+    public static final String TABLE_NAME = "notifications";
+
+    public static final String IDX_USER_CREATED_AT_DESC = "idx_notifications_user_created_at_desc";
+    public static final String IDX_USER_READ_AT = "idx_notifications_user_read_at";
+
+    public static final String USER_ID = "user_id";
+    public static final String DELIVERY_ID = "delivery_id";
+    public static final String TYPE = "type";
+    public static final String CATEGORY = "category";
+    public static final String TITLE = "title";
+    public static final String MESSAGE = "message";
+    public static final String PAYLOAD_JSON = "payload_json";
+    public static final String CREATED_AT = "created_at";
+    public static final String READ_AT = "read_at";
+
+    private NotificationId() {
+        throw new IllegalStateException("Constants only class");
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/repository/NotificationRepository.java
@@ -1,0 +1,42 @@
+package com.ubb.deliveryhub.notification.repository;
+
+import com.ubb.deliveryhub.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID>, JpaSpecificationExecutor<Notification> {
+
+    boolean existsByIdAndUser_Id(UUID id, UUID userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Notification n
+        SET n.readAt = :readAt
+        WHERE n.id = :id
+          AND n.user.id = :userId
+          AND n.readAt IS NULL
+        """)
+    int markReadIfUnread(
+        @Param("id") UUID id,
+        @Param("userId") UUID userId,
+        @Param("readAt") Instant readAt
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Notification n
+        SET n.readAt = :readAt
+        WHERE n.user.id = :userId
+          AND n.readAt IS NULL
+        """)
+    int markAllRead(
+        @Param("userId") UUID userId,
+        @Param("readAt") Instant readAt
+    );
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/repository/NotificationSpecifications.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/repository/NotificationSpecifications.java
@@ -1,0 +1,37 @@
+package com.ubb.deliveryhub.notification.repository;
+
+import com.ubb.deliveryhub.identity.domain.User;
+import com.ubb.deliveryhub.notification.domain.Notification;
+import com.ubb.deliveryhub.notification.domain.NotificationType;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public final class NotificationSpecifications {
+
+    private NotificationSpecifications() {
+    }
+
+    public static Specification<Notification> forUserWithFilters(
+        UUID userId,
+        Boolean unreadOnly,
+        NotificationType type
+    ) {
+        return (root, query, cb) -> {
+            Join<Notification, User> userJoin = root.join("user", JoinType.INNER);
+            List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(userJoin.get("id"), userId));
+            if (Boolean.TRUE.equals(unreadOnly)) {
+                predicates.add(cb.isNull(root.get("readAt")));
+            }
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            return cb.and(predicates.toArray(jakarta.persistence.criteria.Predicate[]::new));
+        };
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationMapper.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationMapper.java
@@ -1,0 +1,24 @@
+package com.ubb.deliveryhub.notification.service;
+
+import com.ubb.deliveryhub.notification.domain.Notification;
+import com.ubb.deliveryhub.notification.domain.dto.NotificationDto;
+
+public final class NotificationMapper {
+
+    private NotificationMapper() {
+    }
+
+    public static NotificationDto toDto(Notification notification) {
+        return NotificationDto.builder()
+            .id(notification.getId().toString())
+            .type(notification.getType().name())
+            .category(notification.getCategory().name())
+            .title(notification.getTitle())
+            .message(notification.getMessage())
+            .deliveryId(notification.getDelivery() != null ? notification.getDelivery().getId().toString() : null)
+            .createdAt(notification.getCreatedAt())
+            .read(notification.getReadAt() != null)
+            .readAt(notification.getReadAt())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationService.java
@@ -1,0 +1,102 @@
+package com.ubb.deliveryhub.notification.service;
+
+import com.ubb.deliveryhub.notification.NotificationListDefaults;
+import com.ubb.deliveryhub.notification.domain.Notification;
+import com.ubb.deliveryhub.notification.domain.NotificationType;
+import com.ubb.deliveryhub.notification.domain.dto.MarkAllReadResponse;
+import com.ubb.deliveryhub.notification.domain.dto.NotificationDto;
+import com.ubb.deliveryhub.notification.domain.exception.InvalidNotificationSortException;
+import com.ubb.deliveryhub.notification.domain.exception.NotificationNotFoundException;
+import com.ubb.deliveryhub.notification.repository.NotificationRepository;
+import com.ubb.deliveryhub.notification.repository.NotificationSpecifications;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of("createdAt", "readAt", "type", "category");
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public Page<NotificationDto> listForCurrentUser(
+        Authentication authentication,
+        Pageable pageable,
+        Boolean unreadOnly,
+        NotificationType type
+    ) {
+        assertAllowedSort(pageable.getSort());
+        Pageable effective = applyDefaultSort(pageable);
+        UUID userId = principalUserId(authentication);
+        Specification<Notification> specification = NotificationSpecifications.forUserWithFilters(userId, unreadOnly, type);
+        return notificationRepository.findAll(specification, effective).map(NotificationMapper::toDto);
+    }
+
+    @Transactional
+    public void markReadForCurrentUser(UUID notificationId, Authentication authentication) {
+        UUID userId = principalUserId(authentication);
+        Instant now = Instant.now();
+        int updated = notificationRepository.markReadIfUnread(notificationId, userId, now);
+        if (updated > 0) {
+            return;
+        }
+        if (!notificationRepository.existsByIdAndUser_Id(notificationId, userId)) {
+            throw new NotificationNotFoundException();
+        }
+    }
+
+    @Transactional
+    public MarkAllReadResponse markAllReadForCurrentUser(Authentication authentication) {
+        UUID userId = principalUserId(authentication);
+        int updatedCount = notificationRepository.markAllRead(userId, Instant.now());
+        return MarkAllReadResponse.builder()
+            .updatedCount(updatedCount)
+            .build();
+    }
+
+    private static UUID principalUserId(Authentication authentication) {
+        return UUID.fromString(authentication.getName());
+    }
+
+    private static void assertAllowedSort(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return;
+        }
+        for (Sort.Order order : sort) {
+            if (!ALLOWED_SORT_PROPERTIES.contains(order.getProperty())) {
+                throw new InvalidNotificationSortException(order.getProperty(), ALLOWED_SORT_PROPERTIES);
+            }
+        }
+    }
+
+    private static Pageable applyDefaultSort(Pageable pageable) {
+        if (pageable == null || pageable.isUnpaged()) {
+            return PageRequest.of(
+                0,
+                NotificationListDefaults.PAGE_SIZE,
+                Sort.by(Sort.Direction.DESC, NotificationListDefaults.SORT_PROPERTY)
+            );
+        }
+        if (!pageable.getSort().isUnsorted()) {
+            return pageable;
+        }
+        return PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            Sort.by(Sort.Direction.DESC, NotificationListDefaults.SORT_PROPERTY)
+        );
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/service/NotificationService.java
@@ -38,8 +38,8 @@ public class NotificationService {
         Boolean unreadOnly,
         NotificationType type
     ) {
-        assertAllowedSort(pageable.getSort());
         Pageable effective = applyDefaultSort(pageable);
+        assertAllowedSort(effective.getSort());
         UUID userId = principalUserId(authentication);
         Specification<Notification> specification = NotificationSpecifications.forUserWithFilters(userId, unreadOnly, type);
         return notificationRepository.findAll(specification, effective).map(NotificationMapper::toDto);

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/web/NotificationController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/web/NotificationController.java
@@ -1,0 +1,62 @@
+package com.ubb.deliveryhub.notification.web;
+
+import com.ubb.deliveryhub.notification.NotificationListDefaults;
+import com.ubb.deliveryhub.notification.domain.NotificationType;
+import com.ubb.deliveryhub.notification.domain.dto.MarkAllReadResponse;
+import com.ubb.deliveryhub.notification.domain.dto.NotificationDto;
+import com.ubb.deliveryhub.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public Page<NotificationDto> listForCurrentUser(
+        Authentication authentication,
+        @PageableDefault(
+            size = NotificationListDefaults.PAGE_SIZE,
+            sort = NotificationListDefaults.SORT_PROPERTY,
+            direction = Sort.Direction.DESC
+        ) Pageable pageable,
+        @RequestParam(required = false) Boolean unreadOnly,
+        @RequestParam(required = false) NotificationType type
+    ) {
+        return notificationService.listForCurrentUser(authentication, pageable, unreadOnly, type);
+    }
+
+    @PatchMapping("/{id}/read")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<Void> markRead(
+        @PathVariable UUID id,
+        Authentication authentication
+    ) {
+        notificationService.markReadForCurrentUser(id, authentication);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/read-all")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public MarkAllReadResponse markAllRead(Authentication authentication) {
+        return notificationService.markAllReadForCurrentUser(authentication);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/web/NotificationExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/web/NotificationExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.notification.web;
+
+import com.ubb.deliveryhub.notification.domain.exception.InvalidNotificationSortException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class NotificationExceptionHandler {
+
+    @ExceptionHandler(InvalidNotificationSortException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidSort(InvalidNotificationSortException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setProperty("invalidSortProperty", ex.getInvalidProperty());
+        pd.setProperty("allowedSortProperties", ex.getAllowedProperties());
+        return ResponseEntity.badRequest().body(pd);
+    }
+}

--- a/backend/src/main/resources/db/migration/V11__notifications.sql
+++ b/backend/src/main/resources/db/migration/V11__notifications.sql
@@ -1,0 +1,33 @@
+-- Task #46: in-app notifications persistence for customer feed (list/read/read-all).
+-- Immutable message content + mutable read_at metadata.
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    delivery_id UUID REFERENCES deliveries (id) ON DELETE SET NULL,
+    type VARCHAR(64) NOT NULL
+        CHECK (type IN (
+                          'DELIVERY_ASSIGNED',
+                          'STATUS_UPDATED',
+                          'EXCEPTION_REPORTED',
+                          'DELIVERY_CREATED',
+                          'DELIVERY_CANCELLED',
+                          'SYSTEM_ANNOUNCEMENT'
+            )),
+    category VARCHAR(32) NOT NULL
+        CHECK (category IN ('DELIVERY', 'EXCEPTION', 'SYSTEM', 'ADMIN')),
+    title VARCHAR(255) NOT NULL,
+    message VARCHAR(2000) NOT NULL,
+    payload_json JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    read_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created_at_desc
+    ON notifications (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_read_at
+    ON notifications (user_id, read_at);
+
+COMMENT ON TABLE notifications IS 'Task #46 notification feed backing table.';
+COMMENT ON COLUMN notifications.payload_json IS 'Optional event metadata for richer UI actions (#47/#48).';


### PR DESCRIPTION
This pull request introduces a new, fully documented Notifications API for customers, including endpoints for listing and marking notifications as read, along with the necessary backend domain, repository, service, and web layers. The changes ensure strict user scoping and provide both domain models and DTOs for notifications, with robust filtering, sorting, and pagination support. The documentation and code are aligned for clarity and future extension.

**Notifications API implementation**

* Added a new REST API (`/api/notifications`) for customers to list, filter, and paginate notifications, as well as mark individual or all notifications as read. Endpoints include `GET /notifications`, `PATCH /notifications/{id}/read`, and `PATCH /notifications/read-all`. 
* Implemented the `Notification` JPA entity, enums for notification type and category, and supporting ID constants for table and column names. 

**Repository and filtering**

* Added a JPA repository and specifications to support user-scoped queries with filtering by unread status and type. 

**DTOs, mapping, and responses**

* Introduced DTOs for notifications and marking all as read, with a mapper for converting between entities and DTOs.

**Sorting, paging, and error handling**

* Defined allowed sort properties, default paging, and custom exceptions for invalid sorts and not-found cases. 

All endpoints are strictly scoped to the authenticated customer (no client-provided user IDs), and full API documentation with examples is provided.