### PR TITLE
Emit notifications on assign/status (sync or MQ) (#47)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -188,3 +188,13 @@ Customer notifications persistence and read-state endpoints are available with s
 - `PATCH /api/notifications/read-all` returning `{ "updatedCount": <number> }`
 
 Full contract and examples are documented in `docs/notifications-api.md`.
+
+## Notification emitters (`#47`)
+
+Delivery assignment and milestone status transitions now emit `NotificationRequested` domain events from transactional delivery flows (`accept` + `PATCH status`), and notifications are handled in an `AFTER_COMMIT` listener to avoid rolling back delivery updates on notification failures.
+
+Runtime mode is controlled by properties:
+
+- `notifications.async.enabled=false` (default): listener persists notification rows synchronously.
+- `notifications.async.enabled=true`: listener publishes event payload to RabbitMQ (`notifications.async.exchange` + `notifications.async.routing-key`).
+- `notifications.async.fallback-to-sync=true`: if async publish fails, listener falls back to sync persistence.

--- a/backend/README.md
+++ b/backend/README.md
@@ -191,7 +191,7 @@ Full contract and examples are documented in `docs/notifications-api.md`.
 
 ## Notification emitters (`#47`)
 
-Delivery assignment and milestone status transitions now emit `NotificationRequested` domain events from transactional delivery flows (`accept` + `PATCH status`), and notifications are handled in an `AFTER_COMMIT` listener to avoid rolling back delivery updates on notification failures.
+Delivery assignment and milestone status transitions now emit `NotificationRequested` domain events from transactional delivery flows (`accept` + `PATCH status`), and notifications are handled in an `AFTER_COMMIT` listener to avoid rolling back delivery updates on notification failures. In the current API scope, emitted recipients are customer-only.
 
 Runtime mode is controlled by properties:
 

--- a/backend/docs/notifications-api.md
+++ b/backend/docs/notifications-api.md
@@ -53,7 +53,7 @@ The delivery domain emits `NotificationRequested` events with this serializable 
 
 Current emission points:
 
-- courier accepts a delivery (`POST /deliveries/{id}/accept`) -> customer + courier confirmation notifications
+- courier accepts a delivery (`POST /deliveries/{id}/accept`) -> customer notification
 - courier updates status (`PATCH /deliveries/{id}/status`) -> customer notifications for milestones (`PICKED_UP`, `IN_TRANSIT`, `DELIVERED`)
 
 Processing runs in an `AFTER_COMMIT` listener, so notification failures cannot roll back assignment/status transaction success.

--- a/backend/docs/notifications-api.md
+++ b/backend/docs/notifications-api.md
@@ -38,6 +38,43 @@ Categories:
 - `SYSTEM`
 - `ADMIN`
 
+## Event emission contract (`#47`)
+
+The delivery domain emits `NotificationRequested` events with this serializable payload:
+
+- `eventId`
+- `eventType` (`ASSIGNMENT_ACCEPTED`, `STATUS_UPDATED`, `EXCEPTION_REPORTED`)
+- `deliveryId`
+- `actorUserId`
+- `targetUserIds`
+- `status` (nullable by event type)
+- `occurredAt`
+- `metadata` (optional map)
+
+Current emission points:
+
+- courier accepts a delivery (`POST /deliveries/{id}/accept`) -> customer + courier confirmation notifications
+- courier updates status (`PATCH /deliveries/{id}/status`) -> customer notifications for milestones (`PICKED_UP`, `IN_TRANSIT`, `DELIVERED`)
+
+Processing runs in an `AFTER_COMMIT` listener, so notification failures cannot roll back assignment/status transaction success.
+
+Idempotency keying is persisted as `dedupe_key` (`recipient + delivery + eventType + status`) to avoid duplicate rows on retries/replays.
+
+## Sync vs async mode
+
+Properties:
+
+- `notifications.async.enabled` (default `false`)
+- `notifications.async.fallback-to-sync` (default `true`)
+- `notifications.async.exchange` (default `deliveryhub.notifications`)
+- `notifications.async.routing-key` (default `requested`)
+
+Behavior:
+
+- when async is `false`, listener writes directly to `notifications` table
+- when async is `true`, listener publishes to RabbitMQ for downstream consumer ownership (`#69`)
+- fallback setting controls whether a failed publish is persisted synchronously
+
 ## `GET /notifications`
 
 Returns paginated notifications for the authenticated customer only.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -28,6 +28,9 @@ import com.ubb.deliveryhub.courier.repository.CourierProfileRepository;
 import com.ubb.deliveryhub.identity.domain.User;
 import com.ubb.deliveryhub.identity.domain.exception.EntityNotFoundException;
 import com.ubb.deliveryhub.identity.repository.UserRepository;
+import com.ubb.deliveryhub.notification.application.NotificationEventPublisher;
+import com.ubb.deliveryhub.notification.events.NotificationEventType;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -44,6 +47,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -63,6 +68,11 @@ public class DeliveryService {
     private static final String TRACKING_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final int TRACKING_BODY_LEN = 10;
     private static final int TRACKING_CODE_SAVE_ATTEMPTS = 15;
+    private static final Set<DeliveryStatus> NOTIFIABLE_STATUS_MILESTONES = Set.of(
+        DeliveryStatus.PICKED_UP,
+        DeliveryStatus.IN_TRANSIT,
+        DeliveryStatus.DELIVERED
+    );
 
     private final DeliveryRepository deliveryRepository;
     private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
@@ -71,6 +81,7 @@ public class DeliveryService {
     private final DeliveryAuthorization deliveryAuthorization;
     private final DeliveryStateMachine deliveryStateMachine;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationEventPublisher notificationEventPublisher;
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Transactional
@@ -227,6 +238,7 @@ public class DeliveryService {
         deliveryStatusHistoryRepository.save(historyEntry);
 
         Delivery saved = deliveryRepository.save(delivery);
+        emitAssignmentNotification(saved, courierId, saved.getUpdatedAt());
         var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(saved.getId());
         return DeliveryMapper.toDetailDto(saved, history);
     }
@@ -257,6 +269,7 @@ public class DeliveryService {
 
         Delivery saved = deliveryRepository.save(delivery);
         publishAfterCommit(saved.getId(), fromStatus, targetStatus, courierId, saved.getUpdatedAt());
+        emitStatusNotification(saved, courierId, targetStatus, saved.getUpdatedAt());
         var history = deliveryStatusHistoryRepository.findByDelivery_IdOrderByRecordedAtAsc(saved.getId());
         return DeliveryMapper.toDetailDto(saved, history);
     }
@@ -310,5 +323,44 @@ public class DeliveryService {
                 );
             }
         });
+    }
+
+    private void emitAssignmentNotification(Delivery delivery, UUID actorId, Instant occurredAt) {
+        if (delivery.getCustomer() == null || delivery.getCustomer().getId() == null) {
+            return;
+        }
+        notificationEventPublisher.publish(
+            new NotificationRequested(
+                UUID.randomUUID(),
+                NotificationEventType.ASSIGNMENT_ACCEPTED,
+                delivery.getId(),
+                actorId,
+                List.of(delivery.getCustomer().getId(), actorId),
+                delivery.getStatus(),
+                occurredAt,
+                Map.of("source", "delivery.accept")
+            )
+        );
+    }
+
+    private void emitStatusNotification(Delivery delivery, UUID actorId, DeliveryStatus targetStatus, Instant occurredAt) {
+        if (!NOTIFIABLE_STATUS_MILESTONES.contains(targetStatus)) {
+            return;
+        }
+        if (delivery.getCustomer() == null || delivery.getCustomer().getId() == null) {
+            return;
+        }
+        notificationEventPublisher.publish(
+            new NotificationRequested(
+                UUID.randomUUID(),
+                NotificationEventType.STATUS_UPDATED,
+                delivery.getId(),
+                actorId,
+                List.of(delivery.getCustomer().getId()),
+                targetStatus,
+                occurredAt,
+                Map.of("source", "delivery.status")
+            )
+        );
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -335,7 +335,7 @@ public class DeliveryService {
                 NotificationEventType.ASSIGNMENT_ACCEPTED,
                 delivery.getId(),
                 actorId,
-                List.of(delivery.getCustomer().getId(), actorId),
+                List.of(delivery.getCustomer().getId()),
                 delivery.getStatus(),
                 occurredAt,
                 Map.of("source", "delivery.accept")

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationDraft.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationDraft.java
@@ -1,0 +1,12 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.notification.domain.NotificationCategory;
+import com.ubb.deliveryhub.notification.domain.NotificationType;
+
+public record NotificationDraft(
+    NotificationType type,
+    NotificationCategory category,
+    String title,
+    String message
+) {
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationEventPublisher.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationEventPublisher.java
@@ -1,0 +1,8 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+
+public interface NotificationEventPublisher {
+
+    void publish(NotificationRequested event);
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
@@ -3,8 +3,8 @@ package com.ubb.deliveryhub.notification.application;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ubb.deliveryhub.delivery.domain.Delivery;
 import com.ubb.deliveryhub.identity.domain.User;
-import com.ubb.deliveryhub.identity.repository.UserRepository;
 import com.ubb.deliveryhub.notification.domain.Notification;
+import com.ubb.deliveryhub.notification.domain.id.NotificationId;
 import com.ubb.deliveryhub.notification.events.NotificationRequested;
 import com.ubb.deliveryhub.notification.repository.NotificationRepository;
 import jakarta.persistence.EntityManager;
@@ -20,18 +20,15 @@ import java.util.UUID;
 public class NotificationPersistenceService {
 
     private final NotificationRepository notificationRepository;
-    private final UserRepository userRepository;
     private final EntityManager entityManager;
     private final ObjectMapper objectMapper;
 
     public NotificationPersistenceService(
         NotificationRepository notificationRepository,
-        UserRepository userRepository,
         EntityManager entityManager,
         ObjectMapper objectMapper
     ) {
         this.notificationRepository = notificationRepository;
-        this.userRepository = userRepository;
         this.entityManager = entityManager;
         this.objectMapper = objectMapper;
     }
@@ -58,14 +55,14 @@ public class NotificationPersistenceService {
             notificationRepository.save(notification);
             return true;
         } catch (DataIntegrityViolationException ex) {
-            return false;
+            if (isDedupeViolation(ex)) {
+                return false;
+            }
+            throw ex;
         }
     }
 
     private User requireUserReference(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("Notification target user not found: " + userId);
-        }
         return entityManager.getReference(User.class, userId);
     }
 
@@ -73,6 +70,21 @@ public class NotificationPersistenceService {
         if (deliveryId == null) {
             return null;
         }
-        return entityManager.find(Delivery.class, deliveryId);
+        return entityManager.getReference(Delivery.class, deliveryId);
+    }
+
+    private static boolean isDedupeViolation(Throwable throwable) {
+        Throwable cursor = throwable;
+        while (cursor != null) {
+            String message = cursor.getMessage();
+            if (message != null) {
+                String normalized = message.toLowerCase();
+                if (normalized.contains(NotificationId.IDX_DEDUPE_KEY) || normalized.contains(NotificationId.DEDUPE_KEY)) {
+                    return true;
+                }
+            }
+            cursor = cursor.getCause();
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
@@ -1,0 +1,78 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ubb.deliveryhub.delivery.domain.Delivery;
+import com.ubb.deliveryhub.identity.domain.User;
+import com.ubb.deliveryhub.identity.repository.UserRepository;
+import com.ubb.deliveryhub.notification.domain.Notification;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import com.ubb.deliveryhub.notification.repository.NotificationRepository;
+import jakarta.persistence.EntityManager;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class NotificationPersistenceService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final EntityManager entityManager;
+    private final ObjectMapper objectMapper;
+
+    public NotificationPersistenceService(
+        NotificationRepository notificationRepository,
+        UserRepository userRepository,
+        EntityManager entityManager,
+        ObjectMapper objectMapper
+    ) {
+        this.notificationRepository = notificationRepository;
+        this.userRepository = userRepository;
+        this.entityManager = entityManager;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public boolean persist(NotificationRequested event, UUID recipientUserId, NotificationDraft draft, String dedupeKey) {
+        Notification notification = new Notification();
+        notification.setUser(requireUserReference(recipientUserId));
+        notification.setDelivery(optionalDeliveryReference(event.deliveryId()));
+        notification.setType(draft.type());
+        notification.setCategory(draft.category());
+        notification.setTitle(draft.title());
+        notification.setMessage(draft.message());
+        notification.setDedupeKey(dedupeKey);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("eventId", event.eventId());
+        payload.put("eventType", event.eventType());
+        payload.put("status", event.status());
+        payload.put("occurredAt", event.occurredAt());
+        payload.put("actorUserId", event.actorUserId());
+        payload.put("metadata", event.metadata());
+        notification.setPayloadJson(objectMapper.valueToTree(payload));
+        try {
+            notificationRepository.save(notification);
+            return true;
+        } catch (DataIntegrityViolationException ex) {
+            return false;
+        }
+    }
+
+    private User requireUserReference(UUID userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("Notification target user not found: " + userId);
+        }
+        return entityManager.getReference(User.class, userId);
+    }
+
+    private Delivery optionalDeliveryReference(UUID deliveryId) {
+        if (deliveryId == null) {
+            return null;
+        }
+        return entityManager.find(Delivery.class, deliveryId);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationTemplateService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationTemplateService.java
@@ -1,0 +1,50 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.notification.domain.NotificationCategory;
+import com.ubb.deliveryhub.notification.domain.NotificationType;
+import com.ubb.deliveryhub.notification.events.NotificationEventType;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class NotificationTemplateService {
+
+    public NotificationDraft render(NotificationRequested event, UUID recipientUserId) {
+        return switch (event.eventType()) {
+            case ASSIGNMENT_ACCEPTED -> assignmentAccepted(event, recipientUserId);
+            case STATUS_UPDATED -> statusUpdated(event);
+            case EXCEPTION_REPORTED -> exceptionReported(event);
+        };
+    }
+
+    private static NotificationDraft assignmentAccepted(NotificationRequested event, UUID recipientUserId) {
+        boolean actorIsRecipient = event.actorUserId().equals(recipientUserId);
+        String title = actorIsRecipient ? "Delivery assignment confirmed" : "Courier assigned";
+        String message = actorIsRecipient
+            ? "You are now assigned to delivery %s.".formatted(shortDeliveryCode(event.deliveryId()))
+            : "Your delivery %s was accepted by a courier.".formatted(shortDeliveryCode(event.deliveryId()));
+        return new NotificationDraft(NotificationType.DELIVERY_ASSIGNED, NotificationCategory.DELIVERY, title, message);
+    }
+
+    private static NotificationDraft statusUpdated(NotificationRequested event) {
+        DeliveryStatus status = event.status();
+        String statusLabel = status == null ? "updated" : status.name().replace('_', ' ');
+        String title = "Delivery status updated";
+        String message = "Delivery %s is now %s.".formatted(shortDeliveryCode(event.deliveryId()), statusLabel);
+        return new NotificationDraft(NotificationType.STATUS_UPDATED, NotificationCategory.DELIVERY, title, message);
+    }
+
+    private static NotificationDraft exceptionReported(NotificationRequested event) {
+        String title = "Delivery exception reported";
+        String message = "An exception was reported for delivery %s.".formatted(shortDeliveryCode(event.deliveryId()));
+        return new NotificationDraft(NotificationType.EXCEPTION_REPORTED, NotificationCategory.EXCEPTION, title, message);
+    }
+
+    private static String shortDeliveryCode(UUID deliveryId) {
+        String raw = deliveryId.toString().replace("-", "");
+        return "DH-" + raw.substring(0, Math.min(8, raw.length())).toUpperCase();
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/SpringNotificationEventPublisher.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/SpringNotificationEventPublisher.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringNotificationEventPublisher implements NotificationEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public SpringNotificationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void publish(NotificationRequested event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
@@ -1,0 +1,55 @@
+package com.ubb.deliveryhub.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "notifications")
+public class NotificationProperties {
+
+    private final Async async = new Async();
+
+    public Async getAsync() {
+        return async;
+    }
+
+    public static class Async {
+
+        private boolean enabled = false;
+        private boolean fallbackToSync = true;
+        private String exchange = "deliveryhub.notifications";
+        private String routingKey = "requested";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isFallbackToSync() {
+            return fallbackToSync;
+        }
+
+        public void setFallbackToSync(boolean fallbackToSync) {
+            this.fallbackToSync = fallbackToSync;
+        }
+
+        public String getExchange() {
+            return exchange;
+        }
+
+        public void setExchange(String exchange) {
+            this.exchange = exchange;
+        }
+
+        public String getRoutingKey() {
+            return routingKey;
+        }
+
+        public void setRoutingKey(String routingKey) {
+            this.routingKey = routingKey;
+        }
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
@@ -33,7 +33,7 @@ import java.util.UUID;
     indexes = {
         @Index(name = NotificationId.IDX_USER_CREATED_AT_DESC, columnList = NotificationId.USER_ID + "," + NotificationId.CREATED_AT),
         @Index(name = NotificationId.IDX_USER_READ_AT, columnList = NotificationId.USER_ID + "," + NotificationId.READ_AT),
-        @Index(name = NotificationId.IDX_DEDUPE_KEY, columnList = NotificationId.DEDUPE_KEY, unique = true)
+        @Index(name = NotificationId.IDX_DEDUPE_KEY, columnList = NotificationId.DEDUPE_KEY)
     }
 )
 @Getter

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/Notification.java
@@ -32,7 +32,8 @@ import java.util.UUID;
     name = NotificationId.TABLE_NAME,
     indexes = {
         @Index(name = NotificationId.IDX_USER_CREATED_AT_DESC, columnList = NotificationId.USER_ID + "," + NotificationId.CREATED_AT),
-        @Index(name = NotificationId.IDX_USER_READ_AT, columnList = NotificationId.USER_ID + "," + NotificationId.READ_AT)
+        @Index(name = NotificationId.IDX_USER_READ_AT, columnList = NotificationId.USER_ID + "," + NotificationId.READ_AT),
+        @Index(name = NotificationId.IDX_DEDUPE_KEY, columnList = NotificationId.DEDUPE_KEY, unique = true)
     }
 )
 @Getter
@@ -72,6 +73,9 @@ public class Notification {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = NotificationId.PAYLOAD_JSON)
     private JsonNode payloadJson;
+
+    @Column(name = NotificationId.DEDUPE_KEY, length = 255)
+    private String dedupeKey;
 
     @Column(name = NotificationId.CREATED_AT, nullable = false)
     private Instant createdAt;

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/domain/id/NotificationId.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/domain/id/NotificationId.java
@@ -6,6 +6,7 @@ public final class NotificationId {
 
     public static final String IDX_USER_CREATED_AT_DESC = "idx_notifications_user_created_at_desc";
     public static final String IDX_USER_READ_AT = "idx_notifications_user_read_at";
+    public static final String IDX_DEDUPE_KEY = "idx_notifications_dedupe_key";
 
     public static final String USER_ID = "user_id";
     public static final String DELIVERY_ID = "delivery_id";
@@ -14,6 +15,7 @@ public final class NotificationId {
     public static final String TITLE = "title";
     public static final String MESSAGE = "message";
     public static final String PAYLOAD_JSON = "payload_json";
+    public static final String DEDUPE_KEY = "dedupe_key";
     public static final String CREATED_AT = "created_at";
     public static final String READ_AT = "read_at";
 

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationEventType.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationEventType.java
@@ -1,0 +1,7 @@
+package com.ubb.deliveryhub.notification.events;
+
+public enum NotificationEventType {
+    ASSIGNMENT_ACCEPTED,
+    STATUS_UPDATED,
+    EXCEPTION_REPORTED
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationRequested.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationRequested.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.notification.events;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record NotificationRequested(
+    UUID eventId,
+    NotificationEventType eventType,
+    UUID deliveryId,
+    UUID actorUserId,
+    List<UUID> targetUserIds,
+    DeliveryStatus status,
+    Instant occurredAt,
+    Map<String, Object> metadata
+) {
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/async/NotificationAsyncPublisher.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/async/NotificationAsyncPublisher.java
@@ -1,0 +1,8 @@
+package com.ubb.deliveryhub.notification.infrastructure.async;
+
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+
+public interface NotificationAsyncPublisher {
+
+    void publish(NotificationRequested event);
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationEventRabbitPublisher.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationEventRabbitPublisher.java
@@ -1,0 +1,41 @@
+package com.ubb.deliveryhub.notification.infrastructure.rabbit;
+
+import com.ubb.deliveryhub.notification.config.NotificationProperties;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import com.ubb.deliveryhub.notification.infrastructure.async.NotificationAsyncPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationEventRabbitPublisher implements NotificationAsyncPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationEventRabbitPublisher.class);
+
+    private final RabbitTemplate rabbitTemplate;
+    private final NotificationProperties properties;
+
+    public NotificationEventRabbitPublisher(
+        RabbitTemplate rabbitTemplate,
+        NotificationProperties properties
+    ) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public void publish(NotificationRequested event) {
+        rabbitTemplate.convertAndSend(
+            properties.getAsync().getExchange(),
+            properties.getAsync().getRoutingKey(),
+            event
+        );
+        log.debug(
+            "Published notification event to RabbitMQ eventId={} exchange={} routingKey={}",
+            event.eventId(),
+            properties.getAsync().getExchange(),
+            properties.getAsync().getRoutingKey()
+        );
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
@@ -1,0 +1,15 @@
+package com.ubb.deliveryhub.notification.infrastructure.rabbit;
+
+import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NotificationRabbitConfig {
+
+    @Bean
+    public MessageConverter notificationMessageConverter() {
+        return new JacksonJsonMessageConverter();
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
@@ -60,11 +60,11 @@ public class NotificationRequestedListener {
             persistSynchronously(event);
         } catch (Exception ex) {
             log.warn(
-                "Notification handling failed eventId={} type={} mode={} reason={}",
+                "Notification handling failed eventId={} type={} mode={}",
                 event.eventId(),
                 event.eventType(),
                 mode,
-                ex.getMessage()
+                ex
             );
             if (notificationProperties.getAsync().isEnabled() && notificationProperties.getAsync().isFallbackToSync()) {
                 persistSynchronously(event);
@@ -91,10 +91,10 @@ public class NotificationRequestedListener {
                 }
             } catch (Exception ex) {
                 log.warn(
-                    "Notification draft/persist failed eventId={} recipient={} reason={}",
+                    "Notification draft/persist failed eventId={} recipient={}",
                     event.eventId(),
                     recipientUserId,
-                    ex.getMessage()
+                    ex
                 );
             }
         }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
@@ -1,0 +1,110 @@
+package com.ubb.deliveryhub.notification.listener;
+
+import com.ubb.deliveryhub.notification.application.NotificationDraft;
+import com.ubb.deliveryhub.notification.application.NotificationPersistenceService;
+import com.ubb.deliveryhub.notification.application.NotificationTemplateService;
+import com.ubb.deliveryhub.notification.config.NotificationProperties;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import com.ubb.deliveryhub.notification.infrastructure.async.NotificationAsyncPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+@Component
+public class NotificationRequestedListener {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationRequestedListener.class);
+
+    private final NotificationTemplateService templateService;
+    private final NotificationPersistenceService persistenceService;
+    private final NotificationAsyncPublisher asyncPublisher;
+    private final NotificationProperties notificationProperties;
+
+    public NotificationRequestedListener(
+        NotificationTemplateService templateService,
+        NotificationPersistenceService persistenceService,
+        NotificationAsyncPublisher asyncPublisher,
+        NotificationProperties notificationProperties
+    ) {
+        this.templateService = templateService;
+        this.persistenceService = persistenceService;
+        this.asyncPublisher = asyncPublisher;
+        this.notificationProperties = notificationProperties;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onNotificationRequested(NotificationRequested event) {
+        if (event == null || event.targetUserIds() == null || event.targetUserIds().isEmpty()) {
+            return;
+        }
+        String mode = notificationProperties.getAsync().isEnabled() ? "async" : "sync";
+        log.info(
+            "Notification requested eventId={} type={} deliveryId={} targetCount={} mode={}",
+            event.eventId(),
+            event.eventType(),
+            event.deliveryId(),
+            event.targetUserIds().size(),
+            mode
+        );
+        try {
+            if (notificationProperties.getAsync().isEnabled()) {
+                asyncPublisher.publish(event);
+                return;
+            }
+            persistSynchronously(event);
+        } catch (Exception ex) {
+            log.warn(
+                "Notification handling failed eventId={} type={} mode={} reason={}",
+                event.eventId(),
+                event.eventType(),
+                mode,
+                ex.getMessage()
+            );
+            if (notificationProperties.getAsync().isEnabled() && notificationProperties.getAsync().isFallbackToSync()) {
+                persistSynchronously(event);
+            }
+        }
+    }
+
+    private void persistSynchronously(NotificationRequested event) {
+        for (UUID recipientUserId : event.targetUserIds()) {
+            if (recipientUserId == null) {
+                continue;
+            }
+            try {
+                NotificationDraft draft = templateService.render(event, recipientUserId);
+                String dedupeKey = dedupeKey(event, recipientUserId);
+                boolean persisted = persistenceService.persist(event, recipientUserId, draft, dedupeKey);
+                if (!persisted) {
+                    log.info(
+                        "Skipping duplicate notification eventId={} recipient={} dedupeKey={}",
+                        event.eventId(),
+                        recipientUserId,
+                        dedupeKey
+                    );
+                }
+            } catch (Exception ex) {
+                log.warn(
+                    "Notification draft/persist failed eventId={} recipient={} reason={}",
+                    event.eventId(),
+                    recipientUserId,
+                    ex.getMessage()
+                );
+            }
+        }
+    }
+
+    private static String dedupeKey(NotificationRequested event, UUID recipientUserId) {
+        String statusToken = event.status() == null ? "NA" : event.status().name();
+        String deliveryToken = Objects.toString(event.deliveryId(), "NA");
+        return ("%s:%s:%s:%s")
+            .formatted(recipientUserId, deliveryToken, event.eventType(), statusToken)
+            .toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -22,3 +22,9 @@ spring.flyway.locations=classpath:db/migration
 # JWT Configuration
 jwt.secret=36cd8c7dd84ace459ec4e262e4aa96cd
 jwt.expiration=86400000
+
+# notifications emission toggle (default sync write)
+notifications.async.enabled=false
+notifications.async.fallback-to-sync=true
+notifications.async.exchange=deliveryhub.notifications
+notifications.async.routing-key=requested

--- a/backend/src/main/resources/db/migration/V12__notification_dedupe_key.sql
+++ b/backend/src/main/resources/db/migration/V12__notification_dedupe_key.sql
@@ -1,0 +1,10 @@
+-- Task #47: dedupe support for notification event retries/replays.
+
+ALTER TABLE notifications
+    ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(255);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_dedupe_key
+    ON notifications (dedupe_key)
+    WHERE dedupe_key IS NOT NULL;
+
+COMMENT ON COLUMN notifications.dedupe_key IS 'Idempotency key derived from recipient+delivery+event type+status.';


### PR DESCRIPTION
This pull request introduces domain event-driven notification emission for delivery assignment and milestone status transitions, along with a new infrastructure for notification persistence and async processing. Notifications are now emitted as `NotificationRequested` events from delivery flows, processed after transaction commit, with support for both synchronous and asynchronous (RabbitMQ-based) persistence and idempotency via deduplication keys. The changes include new service classes, configuration, and updates to the data model.

**Notification emission and processing:**

* Delivery assignment and status milestone transitions now emit `NotificationRequested` events in transactional flows, handled after commit to prevent notification failures from rolling back delivery updates.
* Added `NotificationEventPublisher` abstraction and default Spring-based publisher for event emission. 

**Notification persistence and idempotency:**

* Introduced `NotificationPersistenceService` for robust notification row creation, including deduplication via a new unique `dedupe_key` column and index in the `Notification` entity.
* Notification events are rendered to user-facing drafts by a new `NotificationTemplateService`. 

**Async notification delivery support:**

* Added configuration for async notification processing (RabbitMQ-based) with fallback to sync persistence. New properties are documented and exposed via `NotificationProperties`.

**Documentation and contracts:**

* Updated API and event emission contracts in `docs/notifications-api.md` and `README.md`, describing event payloads, emission points, and async/sync modes. 

**Event types:**

* Introduced `NotificationEventType` enum to standardize event kinds (`ASSIGNMENT_ACCEPTED`, `STATUS_UPDATED`, `EXCEPTION_REPORTED`). 