### PR TITLE
Admin dashboard page (charts) (#53)

### DIFF
--- a/backend/docs/admin-dashboard-api.md
+++ b/backend/docs/admin-dashboard-api.md
@@ -33,6 +33,8 @@ Fields:
 - `exceptionBacklogCount`
 - `generatedAt` (UTC instant)
 - `window` (`from`, `to`, `timezone`)
+- `deliveryVolumeSeries` (daily buckets in selected window; label = `YYYY-MM-DD`, value = count)
+- `statusDistributionSeries` (delivery status grouped counts in selected window)
 
 All numeric metrics are zero-safe (never `null`).
 
@@ -50,7 +52,17 @@ Example response:
     "from": "2026-05-07T14:00:00Z",
     "to": "2026-05-14T14:00:00Z",
     "timezone": "UTC"
-  }
+  },
+  "deliveryVolumeSeries": [
+    { "label": "2026-05-08", "value": 1 },
+    { "label": "2026-05-09", "value": 2 },
+    { "label": "2026-05-10", "value": 0 }
+  ],
+  "statusDistributionSeries": [
+    { "label": "CREATED", "value": 3 },
+    { "label": "ASSIGNED", "value": 2 },
+    { "label": "IN_TRANSIT", "value": 1 }
+  ]
 }
 ```
 

--- a/backend/src/main/java/com/ubb/deliveryhub/admin/domain/dto/AdminDashboardDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/admin/domain/dto/AdminDashboardDto.java
@@ -5,6 +5,7 @@ import lombok.Value;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 
 @Value
 @Builder
@@ -16,4 +17,6 @@ public class AdminDashboardDto {
     long exceptionBacklogCount;
     Instant generatedAt;
     AdminDashboardWindowDto window;
+    List<AdminDashboardSeriesPointDto> deliveryVolumeSeries;
+    List<AdminDashboardSeriesPointDto> statusDistributionSeries;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/admin/domain/dto/AdminDashboardSeriesPointDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/admin/domain/dto/AdminDashboardSeriesPointDto.java
@@ -1,0 +1,11 @@
+package com.ubb.deliveryhub.admin.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AdminDashboardSeriesPointDto {
+    String label;
+    long value;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminDashboardService.java
@@ -174,10 +174,10 @@ public class AdminDashboardService {
         }
 
         LocalDate fromDate = window.fromInclusive().atOffset(ZoneOffset.UTC).toLocalDate();
-        LocalDate toExclusiveDate = window.toExclusive().atOffset(ZoneOffset.UTC).toLocalDate();
+        LocalDate toInclusiveDate = window.toExclusive().minusNanos(1).atOffset(ZoneOffset.UTC).toLocalDate();
 
         List<AdminDashboardSeriesPointDto> series = new ArrayList<>();
-        for (LocalDate cursor = fromDate; cursor.isBefore(toExclusiveDate); cursor = cursor.plusDays(1)) {
+        for (LocalDate cursor = fromDate; !cursor.isAfter(toInclusiveDate); cursor = cursor.plusDays(1)) {
             series.add(AdminDashboardSeriesPointDto.builder()
                 .label(cursor.toString())
                 .value(countByDate.getOrDefault(cursor, 0L))

--- a/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminDashboardService.java
@@ -1,10 +1,13 @@
 package com.ubb.deliveryhub.admin.service;
 
 import com.ubb.deliveryhub.admin.domain.dto.AdminDashboardDto;
+import com.ubb.deliveryhub.admin.domain.dto.AdminDashboardSeriesPointDto;
 import com.ubb.deliveryhub.admin.domain.dto.AdminDashboardWindowDto;
 import com.ubb.deliveryhub.admin.domain.exception.AdminDashboardValidationException;
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import com.ubb.deliveryhub.delivery.repository.DeliveryDateCountView;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
+import com.ubb.deliveryhub.delivery.repository.DeliveryStatusCountView;
 import com.ubb.deliveryhub.notification.domain.NotificationCategory;
 import com.ubb.deliveryhub.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,8 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +90,9 @@ public class AdminDashboardService {
             window.toExclusive()
         );
 
+        List<AdminDashboardSeriesPointDto> deliveryVolumeSeries = buildDeliveryVolumeSeries(window);
+        List<AdminDashboardSeriesPointDto> statusDistributionSeries = buildStatusDistributionSeries(window);
+
         return AdminDashboardDto.builder()
             .activeDeliveriesCount(activeDeliveriesCount)
             .couriersOnlineCount(couriersOnlineCount)
@@ -99,6 +107,8 @@ public class AdminDashboardService {
                     .timezone(WINDOW_TIMEZONE)
                     .build()
             )
+            .deliveryVolumeSeries(deliveryVolumeSeries)
+            .statusDistributionSeries(statusDistributionSeries)
             .build();
     }
 
@@ -145,6 +155,54 @@ public class AdminDashboardService {
         }
 
         return new DashboardWindow(fromInclusive, toExclusive);
+    }
+
+    private List<AdminDashboardSeriesPointDto> buildDeliveryVolumeSeries(DashboardWindow window) {
+        List<DeliveryDateCountView> groupedRows = deliveryRepository.countByStatusesGroupedByCreatedDateInWindow(
+            ACTIVE_DELIVERY_STATUSES,
+            window.fromInclusive(),
+            window.toExclusive()
+        );
+
+        Map<LocalDate, Long> countByDate = new HashMap<>();
+        for (DeliveryDateCountView row : groupedRows) {
+            LocalDate bucketDate = row.getBucketDate();
+            if (bucketDate == null) {
+                continue;
+            }
+            countByDate.put(bucketDate, Math.max(0, row.getMetricValue()));
+        }
+
+        LocalDate fromDate = window.fromInclusive().atOffset(ZoneOffset.UTC).toLocalDate();
+        LocalDate toExclusiveDate = window.toExclusive().atOffset(ZoneOffset.UTC).toLocalDate();
+
+        List<AdminDashboardSeriesPointDto> series = new ArrayList<>();
+        for (LocalDate cursor = fromDate; cursor.isBefore(toExclusiveDate); cursor = cursor.plusDays(1)) {
+            series.add(AdminDashboardSeriesPointDto.builder()
+                .label(cursor.toString())
+                .value(countByDate.getOrDefault(cursor, 0L))
+                .build());
+        }
+        return series;
+    }
+
+    private List<AdminDashboardSeriesPointDto> buildStatusDistributionSeries(DashboardWindow window) {
+        List<DeliveryStatusCountView> groupedRows = deliveryRepository.countGroupedByStatusInCreatedWindow(
+            window.fromInclusive(),
+            window.toExclusive()
+        );
+
+        List<AdminDashboardSeriesPointDto> series = new ArrayList<>();
+        for (DeliveryStatusCountView row : groupedRows) {
+            if (row.getStatus() == null) {
+                continue;
+            }
+            series.add(AdminDashboardSeriesPointDto.builder()
+                .label(row.getStatus().name())
+                .value(Math.max(0, row.getMetricValue()))
+                .build());
+        }
+        return series;
     }
 
     private Instant parseFromBoundary(String raw, String fieldName) {

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryDateCountView.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryDateCountView.java
@@ -1,0 +1,9 @@
+package com.ubb.deliveryhub.delivery.repository;
+
+import java.time.LocalDate;
+
+public interface DeliveryDateCountView {
+    LocalDate getBucketDate();
+
+    long getMetricValue();
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -124,4 +124,36 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
         @Param("fromInclusive") Instant fromInclusive,
         @Param("toExclusive") Instant toExclusive
     );
+
+    @Query("""
+        SELECT
+          FUNCTION('date', d.createdAt) AS bucketDate,
+          COUNT(d) AS metricValue
+        FROM Delivery d
+        WHERE d.status IN :statuses
+          AND d.createdAt >= :fromInclusive
+          AND d.createdAt < :toExclusive
+        GROUP BY FUNCTION('date', d.createdAt)
+        ORDER BY FUNCTION('date', d.createdAt) ASC
+        """)
+    List<DeliveryDateCountView> countByStatusesGroupedByCreatedDateInWindow(
+        @Param("statuses") Set<DeliveryStatus> statuses,
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
+
+    @Query("""
+        SELECT
+          d.status AS status,
+          COUNT(d) AS metricValue
+        FROM Delivery d
+        WHERE d.createdAt >= :fromInclusive
+          AND d.createdAt < :toExclusive
+        GROUP BY d.status
+        ORDER BY COUNT(d) DESC, d.status ASC
+        """)
+    List<DeliveryStatusCountView> countGroupedByStatusInCreatedWindow(
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -127,14 +127,14 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
 
     @Query("""
         SELECT
-          FUNCTION('date', d.createdAt) AS bucketDate,
+          FUNCTION('date', FUNCTION('timezone', 'UTC', d.createdAt)) AS bucketDate,
           COUNT(d) AS metricValue
         FROM Delivery d
         WHERE d.status IN :statuses
           AND d.createdAt >= :fromInclusive
           AND d.createdAt < :toExclusive
-        GROUP BY FUNCTION('date', d.createdAt)
-        ORDER BY FUNCTION('date', d.createdAt) ASC
+        GROUP BY FUNCTION('date', FUNCTION('timezone', 'UTC', d.createdAt))
+        ORDER BY FUNCTION('date', FUNCTION('timezone', 'UTC', d.createdAt)) ASC
         """)
     List<DeliveryDateCountView> countByStatusesGroupedByCreatedDateInWindow(
         @Param("statuses") Set<DeliveryStatus> statuses,

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusCountView.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusCountView.java
@@ -1,0 +1,9 @@
+package com.ubb.deliveryhub.delivery.repository;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+public interface DeliveryStatusCountView {
+    DeliveryStatus getStatus();
+
+    long getMetricValue();
+}

--- a/frontend/docs/admin-dashboard-ui.md
+++ b/frontend/docs/admin-dashboard-ui.md
@@ -1,0 +1,29 @@
+# Admin dashboard UI notes
+
+## Route
+
+- `/admin/dashboard` (ADMIN-only via existing route-level guards).
+
+## Live API wiring
+
+- Data source: `GET /api/admin/dashboard` with optional `from` and `to` query params.
+- Date-only values are passed through to backend normalization rules (UTC, inclusive `from`, exclusive `to`).
+
+## Fallback behavior
+
+- KPI cards are always rendered when aggregate payload is available.
+- Chart widgets are optional:
+  - if backend returns series data, charts render via PrimeNG `p-chart`;
+  - if series data is absent/malformed, UI derives fallback chart datasets from KPI values and shows a non-blocking warning.
+- On refresh failure after at least one successful load, the page keeps the last successful snapshot and shows a warning banner instead of blanking content.
+
+## Manual acceptance checklist
+
+- [ ] Admin can open `/admin/dashboard` from sidebar navigation.
+- [ ] KPI values render from live backend payload (zero values still shown).
+- [ ] Apply/Clear date filters trigger new API calls.
+- [ ] Hard failure state displays retry action.
+- [ ] Refresh failure preserves previous data snapshot.
+- [ ] Layout remains readable on desktop/tablet/mobile.
+
+Testing artifacts are intentionally manual-only for this task.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "^21.2.0",
     "@primeng/themes": "^21.0.4",
     "@stomp/stompjs": "^7.3.0",
+    "chart.js": "^4.5.1",
     "primeicons": "^7.0.0",
     "primeng": "^21.1.4",
     "rxjs": "~7.8.0",

--- a/frontend/src/app/core/navigation/app-nav.config.ts
+++ b/frontend/src/app/core/navigation/app-nav.config.ts
@@ -26,7 +26,7 @@ export const APP_NAV_SECTIONS: readonly NavSection[] = [
       },
       {
         label: 'Dashboard',
-        routerCommands: ['admin'],
+        routerCommands: ['admin', 'dashboard'],
         icon: 'pi pi-home',
         roles: [UserRole.ADMIN],
         linkActiveExact: true,
@@ -75,12 +75,6 @@ export const APP_NAV_SECTIONS: readonly NavSection[] = [
         roles: [UserRole.COURIER],
       },
       {
-        label: 'Deliveries monitoring',
-        routerCommands: ['admin', 'deliveries'],
-        icon: 'pi pi-truck',
-        roles: [UserRole.ADMIN],
-      },
-      {
         label: 'Couriers',
         routerCommands: ['admin', 'couriers'],
         icon: 'pi pi-users',
@@ -90,12 +84,6 @@ export const APP_NAV_SECTIONS: readonly NavSection[] = [
         label: 'Customers',
         routerCommands: ['admin', 'customers'],
         icon: 'pi pi-user',
-        roles: [UserRole.ADMIN],
-      },
-      {
-        label: 'Exceptions',
-        routerCommands: ['admin', 'exceptions'],
-        icon: 'pi pi-exclamation-triangle',
         roles: [UserRole.ADMIN],
       },
     ],

--- a/frontend/src/app/features/admin/admin.routes.ts
+++ b/frontend/src/app/features/admin/admin.routes.ts
@@ -8,9 +8,19 @@ const loadStub = () =>
 export const adminRoutes: Routes = [
   {
     path: '',
-    data: { pageTitle: 'Dashboard' },
+    pathMatch: 'full',
+    redirectTo: 'dashboard',
+  },
+  {
+    path: 'dashboard',
+    data: {
+      pageTitle: 'Dashboard',
+      subtitle: 'System overview and key performance indicators',
+    },
     loadComponent: () =>
-      import('./pages/admin-home/admin-home').then((m) => m.AdminHome),
+      import('./pages/dashboard/admin-dashboard.component').then(
+        (m) => m.AdminDashboardComponent,
+      ),
   },
   {
     path: 'deliveries',

--- a/frontend/src/app/features/admin/models/admin-dashboard.models.ts
+++ b/frontend/src/app/features/admin/models/admin-dashboard.models.ts
@@ -1,0 +1,32 @@
+export interface AdminDashboardWindowDto {
+  from: string;
+  to: string;
+  timezone: string;
+}
+
+export interface AdminDashboardSeriesPointDto {
+  label: string;
+  value: number;
+}
+
+export interface AdminDashboardDto {
+  activeDeliveriesCount: number;
+  couriersOnlineCount: number;
+  revenueTotal: number;
+  revenueCurrency: string;
+  exceptionBacklogCount: number;
+  generatedAt: string;
+  window: AdminDashboardWindowDto;
+  deliveryVolumeSeries: AdminDashboardSeriesPointDto[] | null;
+  statusDistributionSeries: AdminDashboardSeriesPointDto[] | null;
+}
+
+export interface AdminDashboardQueryParams {
+  from?: string;
+  to?: string;
+}
+
+export interface AdminDashboardUiError {
+  status: number;
+  detail: string | null;
+}

--- a/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.html
+++ b/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.html
@@ -122,7 +122,7 @@
         <div class="grid gap-4 xl:grid-cols-[2fr_1fr]">
           <article class="rounded-(--p-radius-md) border border-p-surface-border bg-white p-3">
             <div class="-mx-3 mb-4 border-b border-p-surface-border px-3 pb-3">
-              <h3 class="text-sm font-semibold text-p-text-primary">Delivery Trend Today</h3>
+              <h3 class="text-sm font-semibold text-p-text-primary">Delivery Trend</h3>
             </div>
             @if (lineChartData(); as trendChart) {
               <div class="h-[280px] px-1 pb-1">

--- a/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.html
+++ b/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.html
@@ -1,0 +1,170 @@
+<div class="flex min-h-0 flex-1 flex-col bg-p-surface-ground">
+  <div class="space-y-5 p-5">
+    @if (loading() && !hasLoadedAtLeastOnce()) {
+      <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        @for (_card of loadingSkeletonCards; track _card) {
+          <article
+            class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
+          >
+            <div class="space-y-2">
+              <p-skeleton width="8rem" height="0.9rem" />
+              <p-skeleton width="6rem" height="1.8rem" />
+            </div>
+          </article>
+        }
+      </section>
+    } @else if (hardError(); as loadError) {
+      <section
+        class="rounded-(--p-radius-lg) border border-red-200 bg-red-50 p-5 text-sm text-red-700 shadow-(--p-shadow-xs)"
+      >
+        <p class="font-semibold">Dashboard unavailable</p>
+        <p class="mt-1">{{ loadError }}</p>
+        <div class="mt-3">
+          <p-button label="Retry" icon="pi pi-refresh" (onClick)="retry()" />
+        </div>
+      </section>
+    } @else if (dashboard()) {
+      <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        @for (card of kpiCards(); track card.label) {
+          <article
+            class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="mb-1 text-[12px] text-p-text-muted">{{ card.label }}</p>
+                <p class="text-[28px] leading-none font-semibold text-p-text-primary">
+                  {{ card.value }}
+                </p>
+              </div>
+              <span
+                class="inline-flex h-10 w-10 items-center justify-center rounded-(--p-radius-md)"
+                [class]="card.iconBgClass + ' ' + card.iconColorClass"
+              >
+                <i [class]="card.icon + ' text-base'" aria-hidden="true"></i>
+              </span>
+            </div>
+          </article>
+        }
+      </section>
+
+      @if (transientError(); as refreshError) {
+        <section
+          class="rounded-(--p-radius-lg) border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700"
+        >
+          <span class="font-semibold">Refresh failed.</span>
+          <span class="ml-1">{{ refreshError }}</span>
+          <span class="ml-1">Showing last successful snapshot.</span>
+        </section>
+      }
+
+      @if (chartWarnings().length > 0) {
+        <section
+          class="rounded-(--p-radius-lg) border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-700"
+        >
+          @for (warning of chartWarnings(); track warning) {
+            <p>{{ warning }}</p>
+          }
+        </section>
+      }
+
+      <section
+        class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
+      >
+        <div
+          class="mb-4 flex flex-wrap items-end justify-center gap-3 border-b border-p-surface-border pb-3"
+        >
+          <div class="flex flex-wrap items-end gap-2">
+            <label class="flex min-w-32 flex-col gap-1 text-xs text-p-text-muted">
+              From
+              <input
+                type="date"
+                class="rounded-(--p-radius-md) border border-p-surface-border bg-p-surface-ground px-2 py-1.5 text-sm text-p-text-primary"
+                [value]="fromDate()"
+                [disabled]="loading() || refreshing()"
+                (change)="updateFromDate($any($event.target).value)"
+              />
+            </label>
+            <label class="flex min-w-32 flex-col gap-1 text-xs text-p-text-muted">
+              To
+              <input
+                type="date"
+                class="rounded-(--p-radius-md) border border-p-surface-border bg-p-surface-ground px-2 py-1.5 text-sm text-p-text-primary"
+                [value]="toDate()"
+                [disabled]="loading() || refreshing()"
+                (change)="updateToDate($any($event.target).value)"
+              />
+            </label>
+            <div class="flex flex-wrap gap-2">
+              <p-button
+                label="Apply"
+                icon="pi pi-filter"
+                size="small"
+                [disabled]="loading() || refreshing()"
+                (onClick)="applyDateRange()"
+              />
+              <p-button
+                label="Clear"
+                icon="pi pi-times"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                [disabled]="loading() || refreshing()"
+                (onClick)="clearDateRange()"
+              />
+            </div>
+          </div>
+        </div>
+
+        @if (dateRangeError(); as dateError) {
+          <p class="mb-3 text-xs text-red-600">{{ dateError }}</p>
+        }
+
+        <div class="grid gap-4 xl:grid-cols-[2fr_1fr]">
+          <article class="rounded-(--p-radius-md) border border-p-surface-border bg-white p-3">
+            <div class="-mx-3 mb-4 border-b border-p-surface-border px-3 pb-3">
+              <h3 class="text-sm font-semibold text-p-text-primary">Delivery Trend Today</h3>
+            </div>
+            @if (lineChartData(); as trendChart) {
+              <div class="h-[280px] px-1 pb-1">
+                <p-chart type="line" [data]="trendChart" [options]="lineChartOptions()" />
+              </div>
+            } @else {
+              <p class="text-sm text-p-text-muted">
+                No trend series available for this window yet. KPI cards remain fully active.
+              </p>
+            }
+          </article>
+
+          <article class="rounded-(--p-radius-md) border border-p-surface-border bg-white p-3">
+            <div class="-mx-3 mb-4 border-b border-p-surface-border px-3 pb-3">
+              <h3 class="text-sm font-semibold text-p-text-primary">Delivery Status</h3>
+            </div>
+            @if (pieChartData(); as distributionChart) {
+              <div class="mx-auto h-[160px] max-w-[220px]">
+                <p-chart type="pie" [data]="distributionChart" [options]="pieChartOptions()" />
+              </div>
+              <div class="mt-3 space-y-2">
+                @for (item of pieLegendItems(); track item.label) {
+                  <div class="grid grid-cols-[1fr_auto] items-center gap-2 text-xs">
+                    <span class="inline-flex items-center gap-2 text-p-text-secondary">
+                      <span
+                        class="h-2.5 w-2.5 rounded-full"
+                        [style.background-color]="item.color"
+                      ></span>
+                      {{ item.label }}
+                    </span>
+                    <span class="font-semibold text-p-text-primary">{{ item.value }}</span>
+                  </div>
+                }
+              </div>
+            } @else {
+              <p class="text-sm text-p-text-muted">
+                No grouped distribution data was returned by the API for this period.
+              </p>
+            }
+          </article>
+        </div>
+      </section>
+    }
+  </div>
+</div>

--- a/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.ts
+++ b/frontend/src/app/features/admin/pages/dashboard/admin-dashboard.component.ts
@@ -1,0 +1,331 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Button } from 'primeng/button';
+import { UIChart } from 'primeng/chart';
+import { Skeleton } from 'primeng/skeleton';
+import { finalize } from 'rxjs';
+import { AdminDashboardDto } from '../../models/admin-dashboard.models';
+import { AdminDashboardService } from '../../services/admin-dashboard.service';
+import {
+  DASHBOARD_CHART_COLORS,
+  mapDashboardToCharts,
+} from '../../utils/dashboard-chart.mapper';
+
+interface AdminDashboardKpiCard {
+  label: string;
+  value: string;
+  icon: string;
+  iconColorClass: string;
+  iconBgClass: string;
+}
+
+interface PieLegendItem {
+  label: string;
+  value: number;
+  color: string;
+}
+
+type DashboardLoadMode = 'initial' | 'filter' | 'retry';
+
+@Component({
+  selector: 'app-admin-dashboard',
+  imports: [Button, UIChart, Skeleton],
+  templateUrl: './admin-dashboard.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminDashboardComponent {
+  private readonly adminDashboardService = inject(AdminDashboardService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly loading = signal(false);
+  protected readonly refreshing = signal(false);
+  protected readonly hasLoadedAtLeastOnce = signal(false);
+  protected readonly dashboard = signal<AdminDashboardDto | null>(null);
+  protected readonly hardError = signal<string | null>(null);
+  protected readonly transientError = signal<string | null>(null);
+  protected readonly dateRangeError = signal<string | null>(null);
+  protected readonly chartWarnings = signal<string[]>([]);
+  protected readonly fromDate = signal(this.toInputDate(-2));
+  protected readonly toDate = signal(this.toInputDate(0));
+  protected readonly lineChartData = signal<Record<string, unknown> | null>(null);
+  protected readonly pieChartData = signal<Record<string, unknown> | null>(null);
+  protected readonly lineChartOptions = signal<Record<string, unknown>>({});
+  protected readonly pieChartOptions = signal<Record<string, unknown>>({});
+  protected readonly loadingSkeletonCards = [0, 1, 2];
+
+  protected readonly kpiCards = computed<AdminDashboardKpiCard[]>(() => {
+    const snapshot = this.dashboard();
+    if (!snapshot) {
+      return [];
+    }
+
+    return [
+      {
+        label: 'Active deliveries',
+        value: this.formatNumber(snapshot.activeDeliveriesCount),
+        icon: 'pi pi-truck',
+        iconColorClass: 'text-blue-600',
+        iconBgClass: 'bg-blue-100',
+      },
+      {
+        label: 'Couriers online',
+        value: this.formatNumber(snapshot.couriersOnlineCount),
+        icon: 'pi pi-wifi',
+        iconColorClass: 'text-cyan-600',
+        iconBgClass: 'bg-cyan-100',
+      },
+      {
+        label: 'Revenue',
+        value: this.formatCurrency(snapshot.revenueTotal, snapshot.revenueCurrency),
+        icon: 'pi pi-dollar',
+        iconColorClass: 'text-emerald-600',
+        iconBgClass: 'bg-emerald-100',
+      },
+    ];
+  });
+
+  protected readonly generatedAtLabel = computed(() => {
+    const generatedAt = this.dashboard()?.generatedAt;
+    if (!generatedAt) {
+      return null;
+    }
+
+    const parsed = Date.parse(generatedAt);
+    if (Number.isNaN(parsed)) {
+      return null;
+    }
+
+    return new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    }).format(new Date(parsed));
+  });
+
+  protected readonly windowLabel = computed(() => {
+    const current = this.dashboard();
+    if (!current) {
+      return null;
+    }
+
+    const from = this.formatWindowBoundary(current.window.from);
+    const to = this.formatWindowBoundary(current.window.to);
+    return `${from} -> ${to} (${current.window.timezone})`;
+  });
+
+  protected readonly pieLegendItems = computed<PieLegendItem[]>(() => {
+    const snapshot = this.dashboard();
+    if (!snapshot) {
+      return [];
+    }
+
+    const fromStatusSeries = snapshot.statusDistributionSeries?.map((point, index) => ({
+      label: point.label,
+      value: point.value,
+      color: DASHBOARD_CHART_COLORS.pie[index % DASHBOARD_CHART_COLORS.pie.length],
+    }));
+
+    if (fromStatusSeries && fromStatusSeries.length > 0) {
+      return fromStatusSeries;
+    }
+
+    return [
+      {
+        label: 'Active deliveries',
+        value: snapshot.activeDeliveriesCount,
+        color: DASHBOARD_CHART_COLORS.pie[0],
+      },
+      {
+        label: 'Couriers online',
+        value: snapshot.couriersOnlineCount,
+        color: DASHBOARD_CHART_COLORS.pie[1],
+      },
+      {
+        label: 'Exception backlog',
+        value: snapshot.exceptionBacklogCount,
+        color: DASHBOARD_CHART_COLORS.pie[2],
+      },
+    ];
+  });
+
+  constructor() {
+    this.loadDashboard('initial');
+  }
+
+  protected applyDateRange(): void {
+    if (!this.validateDateRange()) {
+      return;
+    }
+    this.loadDashboard('filter');
+  }
+
+  protected clearDateRange(): void {
+    if (!this.fromDate() && !this.toDate()) {
+      return;
+    }
+    this.fromDate.set('');
+    this.toDate.set('');
+    this.dateRangeError.set(null);
+    this.loadDashboard('filter');
+  }
+
+  protected retry(): void {
+    this.loadDashboard('retry');
+  }
+
+  protected updateFromDate(value: string): void {
+    this.fromDate.set(value);
+    this.dateRangeError.set(null);
+  }
+
+  protected updateToDate(value: string): void {
+    this.toDate.set(value);
+    this.dateRangeError.set(null);
+  }
+
+  protected hasCharts(): boolean {
+    return this.lineChartData() !== null || this.pieChartData() !== null;
+  }
+
+  private loadDashboard(mode: DashboardLoadMode): void {
+    if (this.loading() || this.refreshing()) {
+      return;
+    }
+
+    const currentDashboard = this.dashboard();
+    const hasExistingDashboard = currentDashboard !== null;
+    const queryParams = this.buildQueryParams();
+
+    this.hardError.set(null);
+    this.transientError.set(null);
+    if (hasExistingDashboard || mode !== 'initial') {
+      this.refreshing.set(true);
+    } else {
+      this.loading.set(true);
+    }
+
+    this.adminDashboardService
+      .getDashboard(queryParams)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading.set(false);
+          this.refreshing.set(false);
+        }),
+      )
+      .subscribe({
+        next: (dashboard) => {
+          this.dashboard.set(dashboard);
+          this.hasLoadedAtLeastOnce.set(true);
+          this.applyChartMapping(dashboard);
+        },
+        error: (error: unknown) => {
+          const uiError = this.adminDashboardService.toUiError(error);
+          const detail =
+            uiError.detail ??
+            'Dashboard data could not be loaded. Please retry in a few moments.';
+
+          if (hasExistingDashboard) {
+            this.transientError.set(detail);
+            return;
+          }
+
+          this.hardError.set(detail);
+          this.chartWarnings.set([]);
+          this.lineChartData.set(null);
+          this.pieChartData.set(null);
+        },
+      });
+  }
+
+  private applyChartMapping(dashboard: AdminDashboardDto): void {
+    const chartMapping = mapDashboardToCharts(dashboard);
+    this.lineChartData.set(chartMapping.lineChartData);
+    this.pieChartData.set(chartMapping.pieChartData);
+    this.lineChartOptions.set(chartMapping.lineChartOptions);
+    this.pieChartOptions.set(chartMapping.pieChartOptions);
+    this.chartWarnings.set(chartMapping.warnings);
+  }
+
+  private buildQueryParams(): { from?: string; to?: string } {
+    const from = this.fromDate().trim();
+    const to = this.toDate().trim();
+    return {
+      from: from || undefined,
+      to: to || undefined,
+    };
+  }
+
+  private validateDateRange(): boolean {
+    const from = this.fromDate().trim();
+    const to = this.toDate().trim();
+
+    if (!from || !to) {
+      this.dateRangeError.set(null);
+      return true;
+    }
+
+    const fromEpoch = Date.parse(`${from}T00:00:00Z`);
+    const toEpoch = Date.parse(`${to}T00:00:00Z`);
+    if (Number.isNaN(fromEpoch) || Number.isNaN(toEpoch)) {
+      this.dateRangeError.set('Please use valid date values before applying filters.');
+      return false;
+    }
+
+    if (fromEpoch > toEpoch) {
+      this.dateRangeError.set('"From" date cannot be after "To" date.');
+      return false;
+    }
+
+    this.dateRangeError.set(null);
+    return true;
+  }
+
+  private formatWindowBoundary(value: string): string {
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return '-';
+    }
+
+    return new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    }).format(new Date(parsed));
+  }
+
+  private formatNumber(value: number): string {
+    return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+  }
+
+  private formatCurrency(value: number, currency: string): string {
+    try {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value);
+    } catch {
+      return `${value.toFixed(2)} ${currency}`;
+    }
+  }
+
+  private toInputDate(dayOffset: number): string {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + dayOffset);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/frontend/src/app/features/admin/services/admin-dashboard.service.ts
+++ b/frontend/src/app/features/admin/services/admin-dashboard.service.ts
@@ -132,6 +132,23 @@ export class AdminDashboardService extends BaseService {
       const firstError = errors.find((entry) => this.toText(entry));
       return this.toText(firstError) ?? null;
     }
+    if (errors && typeof errors === 'object') {
+      const errorMap = errors as Record<string, unknown>;
+      for (const fieldName of Object.keys(errorMap)) {
+        const entry = errorMap[fieldName];
+        if (Array.isArray(entry)) {
+          const firstEntry = entry.find((item) => this.toText(item));
+          const message = this.toText(firstEntry);
+          if (message) {
+            return `${fieldName}: ${message}`;
+          }
+        }
+        const singleMessage = this.toText(entry);
+        if (singleMessage) {
+          return `${fieldName}: ${singleMessage}`;
+        }
+      }
+    }
     return null;
   }
 

--- a/frontend/src/app/features/admin/services/admin-dashboard.service.ts
+++ b/frontend/src/app/features/admin/services/admin-dashboard.service.ts
@@ -1,0 +1,176 @@
+import { HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BaseService } from '@core/services/base.service';
+import { map, Observable } from 'rxjs';
+import {
+  AdminDashboardDto,
+  AdminDashboardQueryParams,
+  AdminDashboardSeriesPointDto,
+  AdminDashboardUiError,
+  AdminDashboardWindowDto,
+} from '../models/admin-dashboard.models';
+
+type UnknownRecord = Record<string, unknown>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminDashboardService extends BaseService {
+  getDashboard(params: AdminDashboardQueryParams): Observable<AdminDashboardDto> {
+    const queryParams = this.toQueryParams(params);
+    return this.httpClient
+      .get<unknown>(`${this.baseUrl}/admin/dashboard`, { params: queryParams })
+      .pipe(map((response) => this.normalizeDashboardResponse(response)));
+  }
+
+  toUiError(error: unknown): AdminDashboardUiError {
+    if (!(error instanceof HttpErrorResponse)) {
+      return {
+        status: 0,
+        detail: null,
+      };
+    }
+
+    return {
+      status: error.status,
+      detail: this.extractErrorDetail(error),
+    };
+  }
+
+  private toQueryParams(params: AdminDashboardQueryParams): HttpParams {
+    let queryParams = new HttpParams();
+    if (params.from) {
+      queryParams = queryParams.set('from', params.from);
+    }
+    if (params.to) {
+      queryParams = queryParams.set('to', params.to);
+    }
+    return queryParams;
+  }
+
+  private normalizeDashboardResponse(response: unknown): AdminDashboardDto {
+    const candidate = this.asRecord(response);
+    const nowIso = new Date().toISOString();
+
+    return {
+      activeDeliveriesCount: this.toNonNegativeNumber(candidate['activeDeliveriesCount']),
+      couriersOnlineCount: this.toNonNegativeNumber(candidate['couriersOnlineCount']),
+      revenueTotal: this.toFiniteNumber(candidate['revenueTotal']),
+      revenueCurrency: this.toCurrency(candidate['revenueCurrency']),
+      exceptionBacklogCount: this.toNonNegativeNumber(candidate['exceptionBacklogCount']),
+      generatedAt: this.toIsoDate(candidate['generatedAt']) ?? nowIso,
+      window: this.normalizeWindow(candidate['window'], nowIso),
+      deliveryVolumeSeries: this.normalizeSeriesArray(
+        candidate['deliveryVolumeSeries'] ??
+          candidate['timeSeries'] ??
+          candidate['trendSeries'] ??
+          candidate['deliveryTrendSeries'],
+      ),
+      statusDistributionSeries: this.normalizeSeriesArray(
+        candidate['statusDistributionSeries'] ??
+          candidate['distributionSeries'] ??
+          candidate['statusBreakdown'] ??
+          candidate['statusSeries'],
+      ),
+    };
+  }
+
+  private normalizeWindow(rawWindow: unknown, nowIso: string): AdminDashboardWindowDto {
+    const candidate = this.asRecord(rawWindow);
+    return {
+      from: this.toIsoDate(candidate['from']) ?? nowIso,
+      to: this.toIsoDate(candidate['to']) ?? nowIso,
+      timezone: this.toText(candidate['timezone']) ?? 'UTC',
+    };
+  }
+
+  private normalizeSeriesArray(raw: unknown): AdminDashboardSeriesPointDto[] | null {
+    if (!Array.isArray(raw)) {
+      return null;
+    }
+
+    const normalized = raw
+      .map((item) => this.normalizeSeriesPoint(item))
+      .filter((item): item is AdminDashboardSeriesPointDto => item !== null);
+
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  private normalizeSeriesPoint(raw: unknown): AdminDashboardSeriesPointDto | null {
+    const candidate = this.asRecord(raw);
+    const label =
+      this.toText(candidate['label']) ??
+      this.toText(candidate['name']) ??
+      this.toText(candidate['period']) ??
+      this.toText(candidate['status']);
+    if (!label) {
+      return null;
+    }
+
+    const value = this.toFiniteNumber(
+      candidate['value'] ?? candidate['count'] ?? candidate['total'] ?? candidate['amount'],
+    );
+    return {
+      label,
+      value,
+    };
+  }
+
+  private extractErrorDetail(error: HttpErrorResponse): string | null {
+    const body = this.asRecord(error.error);
+    const detail =
+      this.toText(body['detail']) ??
+      this.toText(body['message']) ??
+      this.toText(body['title']) ??
+      this.toText(body['error']);
+    if (detail) {
+      return detail;
+    }
+
+    const errors = body['errors'];
+    if (Array.isArray(errors)) {
+      const firstError = errors.find((entry) => this.toText(entry));
+      return this.toText(firstError) ?? null;
+    }
+    return null;
+  }
+
+  private asRecord(value: unknown): UnknownRecord {
+    return value && typeof value === 'object' ? (value as UnknownRecord) : {};
+  }
+
+  private toFiniteNumber(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+  }
+
+  private toNonNegativeNumber(value: unknown): number {
+    return Math.max(0, this.toFiniteNumber(value));
+  }
+
+  private toIsoDate(value: unknown): string | null {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      return null;
+    }
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return null;
+    }
+    return new Date(parsed).toISOString();
+  }
+
+  private toCurrency(value: unknown): string {
+    const normalized = this.toText(value);
+    return normalized ? normalized.toUpperCase() : 'RON';
+  }
+
+  private toText(value: unknown): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  }
+}

--- a/frontend/src/app/features/admin/utils/dashboard-chart.mapper.ts
+++ b/frontend/src/app/features/admin/utils/dashboard-chart.mapper.ts
@@ -1,0 +1,223 @@
+import {
+  AdminDashboardDto,
+  AdminDashboardSeriesPointDto,
+} from '../models/admin-dashboard.models';
+
+export const DASHBOARD_CHART_COLORS = {
+  line: {
+    border: '#3b82f6',
+    background: 'rgba(59, 130, 246, 0.16)',
+  },
+  pie: ['#3b82f6', '#f59e0b', '#22c55e', '#06b6d4', '#ef4444'],
+} as const;
+
+export interface DashboardChartMappingResult {
+  lineChartData: Record<string, unknown> | null;
+  pieChartData: Record<string, unknown> | null;
+  lineChartOptions: Record<string, unknown>;
+  pieChartOptions: Record<string, unknown>;
+  warnings: string[];
+}
+
+export function mapDashboardToCharts(
+  dashboard: AdminDashboardDto,
+): DashboardChartMappingResult {
+  const warnings: string[] = [];
+  const lineChartData =
+    buildLineChartData(dashboard.deliveryVolumeSeries) ??
+    buildKpiSnapshotLineData(dashboard);
+  const pieChartData =
+    buildPieChartData(dashboard.statusDistributionSeries) ??
+    buildKpiFallbackDistributionData(dashboard);
+
+  if (!dashboard.deliveryVolumeSeries || dashboard.deliveryVolumeSeries.length === 0) {
+    warnings.push(
+      'Time-series data is missing from API; showing a KPI snapshot fallback chart.',
+    );
+  }
+  if (
+    !dashboard.statusDistributionSeries ||
+    dashboard.statusDistributionSeries.length === 0
+  ) {
+    warnings.push(
+      'Status distribution data is missing from API; showing operational mix fallback chart.',
+    );
+  }
+
+  return {
+    lineChartData,
+    pieChartData,
+    lineChartOptions: createLineChartOptions(),
+    pieChartOptions: createPieChartOptions(),
+    warnings,
+  };
+}
+
+function buildLineChartData(
+  series: AdminDashboardSeriesPointDto[] | null,
+): Record<string, unknown> | null {
+  if (!series || series.length === 0) {
+    return null;
+  }
+
+  return {
+    labels: series.map((point) => point.label),
+    datasets: [
+      {
+        label: 'Deliveries',
+        data: series.map((point) => point.value),
+        borderColor: DASHBOARD_CHART_COLORS.line.border,
+        backgroundColor: DASHBOARD_CHART_COLORS.line.background,
+        borderWidth: 2,
+        tension: 0.3,
+        fill: true,
+        pointRadius: 3,
+        pointHoverRadius: 4,
+      },
+    ],
+  };
+}
+
+function buildPieChartData(
+  series: AdminDashboardSeriesPointDto[] | null,
+): Record<string, unknown> | null {
+  if (!series || series.length === 0) {
+    return null;
+  }
+
+  return {
+    labels: series.map((point) => point.label),
+    datasets: [
+      {
+        data: series.map((point) => point.value),
+        backgroundColor: DASHBOARD_CHART_COLORS.pie,
+        borderColor: '#ffffff',
+        borderWidth: 2,
+      },
+    ],
+  };
+}
+
+function buildKpiSnapshotLineData(
+  dashboard: AdminDashboardDto,
+): Record<string, unknown> {
+  return {
+    labels: ['Active deliveries', 'Couriers online', 'Exception backlog'],
+    datasets: [
+      {
+        label: 'Current window snapshot',
+        data: [
+          dashboard.activeDeliveriesCount,
+          dashboard.couriersOnlineCount,
+          dashboard.exceptionBacklogCount,
+        ],
+        borderColor: DASHBOARD_CHART_COLORS.line.border,
+        backgroundColor: DASHBOARD_CHART_COLORS.line.background,
+        borderWidth: 2,
+        tension: 0.2,
+        fill: true,
+        pointRadius: 3,
+        pointHoverRadius: 4,
+      },
+    ],
+  };
+}
+
+function buildKpiFallbackDistributionData(
+  dashboard: AdminDashboardDto,
+): Record<string, unknown> {
+  return {
+    labels: ['Active deliveries', 'Couriers online', 'Exception backlog'],
+    datasets: [
+      {
+        data: [
+          dashboard.activeDeliveriesCount,
+          dashboard.couriersOnlineCount,
+          dashboard.exceptionBacklogCount,
+        ],
+        backgroundColor: [
+          DASHBOARD_CHART_COLORS.pie[0],
+          DASHBOARD_CHART_COLORS.pie[1],
+          DASHBOARD_CHART_COLORS.pie[2],
+        ],
+        borderColor: '#ffffff',
+        borderWidth: 2,
+      },
+    ],
+  };
+}
+
+function createLineChartOptions(): Record<string, unknown> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      tooltip: {
+        mode: 'index',
+        intersect: false,
+        callbacks: {
+          label(context: { parsed?: { y?: number } }): string {
+            const value =
+              context.parsed && typeof context.parsed.y === 'number'
+                ? context.parsed.y
+                : 0;
+            return `deliveries: ${value}`;
+          },
+        },
+      },
+    },
+    interaction: {
+      mode: 'nearest',
+      intersect: false,
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        suggestedMax: 2,
+        grace: '20%',
+        grid: {
+          color: '#e5e7eb',
+        },
+        ticks: {
+          precision: 0,
+          stepSize: 1,
+          color: '#6b7280',
+        },
+      },
+      x: {
+        grid: {
+          color: '#f3f4f6',
+        },
+        ticks: {
+          maxRotation: 0,
+          minRotation: 0,
+          color: '#6b7280',
+        },
+      },
+    },
+  };
+}
+
+function createPieChartOptions(): Record<string, unknown> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      tooltip: {
+        callbacks: {
+          label(context: { label?: string; parsed?: number }): string {
+            const label = context.label ?? 'Unknown';
+            const value = Number.isFinite(context.parsed) ? Number(context.parsed) : 0;
+            return `${label}: ${value}`;
+          },
+        },
+      },
+    },
+  };
+}

--- a/frontend/src/app/features/admin/utils/dashboard-chart.mapper.ts
+++ b/frontend/src/app/features/admin/utils/dashboard-chart.mapper.ts
@@ -90,7 +90,9 @@ function buildPieChartData(
     datasets: [
       {
         data: series.map((point) => point.value),
-        backgroundColor: DASHBOARD_CHART_COLORS.pie,
+        backgroundColor: series.map(
+          (_point, index) => DASHBOARD_CHART_COLORS.pie[index % DASHBOARD_CHART_COLORS.pie.length],
+        ),
         borderColor: '#ffffff',
         borderWidth: 2,
       },


### PR DESCRIPTION
This pull request introduces new delivery analytics to the admin dashboard, including daily delivery volume and delivery status distribution charts, and updates both backend and frontend to support these features. It adds new DTOs, repository queries, and service logic on the backend, as well as frontend models, navigation, and documentation to wire up and display the new data.

**Backend: Delivery Analytics Data**

* Added two new time-series fields to the admin dashboard API: `deliveryVolumeSeries` (daily delivery counts) and `statusDistributionSeries` (counts grouped by delivery status), with corresponding updates to the API documentation and example responses. 
* Introduced new DTOs (`AdminDashboardSeriesPointDto`) and repository interfaces (`DeliveryDateCountView`, `DeliveryStatusCountView`) to represent and fetch the analytics data.
* Implemented new repository queries and service methods to aggregate delivery counts by date and status for the selected window. 

**Frontend: UI and Navigation Updates**

* Created TypeScript models for the new dashboard DTOs and series data, and updated the navigation to point the "Dashboard" link directly to `/admin/dashboard`. 
* Updated admin routes to load the new dashboard component, and removed obsolete navigation links for "Deliveries monitoring" and "Exceptions." 
* Added Chart.js as a dependency to support chart rendering.

**Documentation**

* Added a new UI documentation file describing API integration, fallback behaviors, and manual acceptance criteria for the admin dashboard.