### PR TITLE
Customer History Page

### DIFF
--- a/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminUserManagementService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/admin/service/AdminUserManagementService.java
@@ -12,6 +12,7 @@ import com.ubb.deliveryhub.admin.domain.exception.InvalidAdminUserSortException;
 import com.ubb.deliveryhub.courier.domain.CourierProfile;
 import com.ubb.deliveryhub.courier.repository.CourierAvailabilityView;
 import com.ubb.deliveryhub.courier.repository.CourierProfileRepository;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.repository.CourierDeliveriesCountView;
 import com.ubb.deliveryhub.delivery.repository.CustomerOrderSpendView;
 import com.ubb.deliveryhub.delivery.repository.DeliveryRepository;
@@ -114,7 +115,7 @@ public class AdminUserManagementService {
         Map<UUID, CustomerOrderSpendView> orderSpendByCustomer = customerIds.isEmpty()
             ? Map.of()
             : deliveryRepository
-                .aggregateCustomerOrdersAndSpend(customerIds)
+                .aggregateCustomerOrdersAndSpend(customerIds, DeliveryStatus.DELIVERED)
                 .stream()
                 .collect(Collectors.toMap(CustomerOrderSpendView::getCustomerId, Function.identity()));
 
@@ -146,7 +147,7 @@ public class AdminUserManagementService {
     @Transactional(readOnly = true)
     public AdminCustomerSummaryDto getCustomerSummary() {
         long totalCustomers = userRepository.countByRole(UserRole.CUSTOMER);
-        BigDecimal totalRevenue = deliveryRepository.sumTotalRevenueForCustomers();
+        BigDecimal totalRevenue = deliveryRepository.sumTotalRevenueForCustomers(DeliveryStatus.DELIVERED);
         return AdminCustomerSummaryDto.builder()
             .totalCustomers(totalCustomers)
             .totalRevenue(totalRevenue != null ? totalRevenue : BigDecimal.ZERO)
@@ -263,7 +264,7 @@ public class AdminUserManagementService {
     }
 
     private String resolveCustomerRevenueCurrency() {
-        List<String> currencies = deliveryRepository.findRevenueCurrenciesForCustomers();
+        List<String> currencies = deliveryRepository.findRevenueCurrenciesForCustomers(DeliveryStatus.DELIVERED);
         if (currencies.isEmpty()) {
             return "RON";
         }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/Delivery.java
@@ -50,7 +50,7 @@ public class Delivery {
     private User courier;
 
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(name = DeliveryId.STATUS, nullable = false)
+    @Column(name = DeliveryId.STATUS, nullable = false, columnDefinition = "delivery_status")
     private DeliveryStatus status;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStatusHistory.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/DeliveryStatusHistory.java
@@ -32,7 +32,7 @@ public class DeliveryStatusHistory {
     private Delivery delivery;
 
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(name = DeliveryStatusHistoryId.STATUS, nullable = false)
+    @Column(name = DeliveryStatusHistoryId.STATUS, nullable = false, columnDefinition = "delivery_status")
     private DeliveryStatus status;
 
     @Column(name = DeliveryStatusHistoryId.RECORDED_AT, nullable = false)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/CustomerHistorySummaryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/domain/dto/CustomerHistorySummaryDto.java
@@ -1,0 +1,15 @@
+package com.ubb.deliveryhub.delivery.domain.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Value
+@Builder
+public class CustomerHistorySummaryDto {
+    long totalDeliveries;
+    long deliveredDeliveries;
+    BigDecimal totalSpent;
+    String totalSpentCurrency;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSpecificationExecutor<Delivery> {
 
     boolean existsByCustomer_IdAndId(UUID customerId, UUID id);
+    long countByCustomer_Id(UUID customerId);
+    long countByCustomer_IdAndStatus(UUID customerId, DeliveryStatus status);
 
     @EntityGraph(attributePaths = {"customer", "courier"})
     @Query("SELECT d FROM Delivery d WHERE d.id = :id")
@@ -157,21 +159,19 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
         @Param("toExclusive") Instant toExclusive
     );
 
-    @Query(
-        value = """
-            SELECT
-              d.customer_id AS customerId,
-              COUNT(d.id) AS ordersCount,
-              COALESCE(SUM(d.total_amount), 0) AS totalSpend
-            FROM deliveries d
-            WHERE d.customer_id IN (:customerIds)
-              AND d.status = 'DELIVERED'::delivery_status
-            GROUP BY d.customer_id
-            """,
-        nativeQuery = true
-    )
+    @Query("""
+        SELECT
+          d.customer.id AS customerId,
+          COUNT(d) AS ordersCount,
+          COALESCE(SUM(d.totalAmount), 0) AS totalSpend
+        FROM Delivery d
+        WHERE d.customer.id IN :customerIds
+          AND d.status = :status
+        GROUP BY d.customer.id
+        """)
     List<CustomerOrderSpendView> aggregateCustomerOrdersAndSpend(
-        @Param("customerIds") List<UUID> customerIds
+        @Param("customerIds") List<UUID> customerIds,
+        @Param("status") DeliveryStatus status
     );
 
     @Query("""
@@ -193,25 +193,45 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
         """)
     long countAllCourierDeliveries();
 
-    @Query(
-        value = """
-            SELECT COALESCE(SUM(d.total_amount), 0)
-            FROM deliveries d
-            WHERE d.status = 'DELIVERED'::delivery_status
-            """,
-        nativeQuery = true
-    )
-    BigDecimal sumTotalRevenueForCustomers();
+    @Query("""
+        SELECT COALESCE(SUM(d.totalAmount), 0)
+        FROM Delivery d
+        WHERE d.status = :status
+        """)
+    BigDecimal sumTotalRevenueForCustomers(@Param("status") DeliveryStatus status);
 
-    @Query(
-        value = """
-            SELECT d.currency
-            FROM deliveries d
-            WHERE d.status = 'DELIVERED'::delivery_status
-            GROUP BY d.currency
-            ORDER BY COUNT(d.id) DESC, d.currency ASC
-            """,
-        nativeQuery = true
-    )
-    List<String> findRevenueCurrenciesForCustomers();
+    @Query("""
+        SELECT d.currency
+        FROM Delivery d
+        WHERE d.status = :status
+        GROUP BY d.currency
+        ORDER BY COUNT(d) DESC, d.currency ASC
+        """)
+    List<String> findRevenueCurrenciesForCustomers(@Param("status") DeliveryStatus status);
+
+    @Query("""
+        SELECT d.currency
+        FROM Delivery d
+        WHERE d.customer.id = :customerId
+          AND d.status = :status
+        GROUP BY d.currency
+        ORDER BY COUNT(d) DESC, d.currency ASC
+        """)
+    List<String> findTopCurrenciesForCustomerByStatus(
+        @Param("customerId") UUID customerId,
+        @Param("status") DeliveryStatus status
+    );
+
+    @Query("""
+        SELECT COALESCE(SUM(d.totalAmount), 0)
+        FROM Delivery d
+        WHERE d.customer.id = :customerId
+          AND d.status = :status
+          AND d.currency = :currency
+        """)
+    BigDecimal sumTotalAmountByCustomerStatusAndCurrency(
+        @Param("customerId") UUID customerId,
+        @Param("status") DeliveryStatus status,
+        @Param("currency") String currency
+    );
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryRepository.java
@@ -157,16 +157,19 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
         @Param("toExclusive") Instant toExclusive
     );
 
-    @Query("""
-        SELECT
-          d.customer.id AS customerId,
-          COUNT(d) AS ordersCount,
-          COALESCE(SUM(d.totalAmount), 0) AS totalSpend
-        FROM Delivery d
-        WHERE d.customer.id IN :customerIds
-          AND d.status = com.ubb.deliveryhub.delivery.domain.DeliveryStatus.DELIVERED
-        GROUP BY d.customer.id
-        """)
+    @Query(
+        value = """
+            SELECT
+              d.customer_id AS customerId,
+              COUNT(d.id) AS ordersCount,
+              COALESCE(SUM(d.total_amount), 0) AS totalSpend
+            FROM deliveries d
+            WHERE d.customer_id IN (:customerIds)
+              AND d.status = 'DELIVERED'::delivery_status
+            GROUP BY d.customer_id
+            """,
+        nativeQuery = true
+    )
     List<CustomerOrderSpendView> aggregateCustomerOrdersAndSpend(
         @Param("customerIds") List<UUID> customerIds
     );
@@ -190,19 +193,25 @@ public interface DeliveryRepository extends JpaRepository<Delivery, UUID>, JpaSp
         """)
     long countAllCourierDeliveries();
 
-    @Query("""
-        SELECT COALESCE(SUM(d.totalAmount), 0)
-        FROM Delivery d
-        WHERE d.status = com.ubb.deliveryhub.delivery.domain.DeliveryStatus.DELIVERED
-        """)
+    @Query(
+        value = """
+            SELECT COALESCE(SUM(d.total_amount), 0)
+            FROM deliveries d
+            WHERE d.status = 'DELIVERED'::delivery_status
+            """,
+        nativeQuery = true
+    )
     BigDecimal sumTotalRevenueForCustomers();
 
-    @Query("""
-        SELECT d.currency
-        FROM Delivery d
-        WHERE d.status = com.ubb.deliveryhub.delivery.domain.DeliveryStatus.DELIVERED
-        GROUP BY d.currency
-        ORDER BY COUNT(d) DESC, d.currency ASC
-        """)
+    @Query(
+        value = """
+            SELECT d.currency
+            FROM deliveries d
+            WHERE d.status = 'DELIVERED'::delivery_status
+            GROUP BY d.currency
+            ORDER BY COUNT(d.id) DESC, d.currency ASC
+            """,
+        nativeQuery = true
+    )
     List<String> findRevenueCurrenciesForCustomers();
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -9,6 +9,7 @@ import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
 import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
+import com.ubb.deliveryhub.delivery.domain.dto.CustomerHistorySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryStatusSnapshotDto;
@@ -152,6 +153,41 @@ public class DeliveryService {
         UUID customerId = principalUserId(authentication);
         Specification<Delivery> spec = DeliverySpecifications.forCustomerWithOptionalStatus(customerId, statusFilter);
         return deliveryRepository.findAll(spec, effective).map(DeliveryMapper::toSummaryDto);
+    }
+
+    @Transactional(readOnly = true)
+    public CustomerHistorySummaryDto getHistorySummaryForCurrentCustomer(Authentication authentication) {
+        UUID customerId = principalUserId(authentication);
+        long totalDeliveries = deliveryRepository.countByCustomer_Id(customerId);
+        long deliveredDeliveries = deliveryRepository.countByCustomer_IdAndStatus(customerId, DeliveryStatus.DELIVERED);
+        if (deliveredDeliveries == 0) {
+            return CustomerHistorySummaryDto.builder()
+                .totalDeliveries(totalDeliveries)
+                .deliveredDeliveries(0)
+                .totalSpent(java.math.BigDecimal.ZERO)
+                .totalSpentCurrency("RON")
+                .build();
+        }
+
+        List<String> currencies = deliveryRepository.findTopCurrenciesForCustomerByStatus(
+            customerId,
+            DeliveryStatus.DELIVERED
+        );
+        String currency = currencies.isEmpty() || currencies.get(0) == null || currencies.get(0).isBlank()
+            ? "RON"
+            : currencies.get(0);
+        var totalSpent = deliveryRepository.sumTotalAmountByCustomerStatusAndCurrency(
+            customerId,
+            DeliveryStatus.DELIVERED,
+            currency
+        );
+
+        return CustomerHistorySummaryDto.builder()
+            .totalDeliveries(totalDeliveries)
+            .deliveredDeliveries(deliveredDeliveries)
+            .totalSpent(totalSpent != null ? totalSpent : java.math.BigDecimal.ZERO)
+            .totalSpentCurrency(currency)
+            .build();
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/web/DeliveryController.java
@@ -5,6 +5,7 @@ import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.domain.DeliveryType;
 import com.ubb.deliveryhub.delivery.domain.dto.AvailableDeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.CreateDeliveryRequest;
+import com.ubb.deliveryhub.delivery.domain.dto.CustomerHistorySummaryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDetailDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryDto;
 import com.ubb.deliveryhub.delivery.domain.dto.DeliveryStatusSnapshotDto;
@@ -54,6 +55,12 @@ public class DeliveryController {
         @RequestParam(required = false) DeliveryStatus status
     ) {
         return deliveryService.listForCurrentCustomer(authentication, pageable, status);
+    }
+
+    @GetMapping("/history/summary")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public CustomerHistorySummaryDto historySummaryForCurrentCustomer(Authentication authentication) {
+        return deliveryService.getHistorySummaryForCurrentCustomer(authentication);
     }
 
     @GetMapping("/available")

--- a/frontend/src/app/core/services/delivery/delivery.ts
+++ b/frontend/src/app/core/services/delivery/delivery.ts
@@ -4,6 +4,7 @@ import { FormGroup } from '@angular/forms';
 import { BaseService } from '@core/services/base.service';
 import {
   CreateDeliveryRequest,
+  CustomerHistorySummaryDto,
   DeliveryCreatedResponse,
   DeliveryDetailDto,
   DeliveryListQuery,
@@ -74,6 +75,12 @@ export class DeliveryService extends BaseService {
     query: DeliveryListQuery = {},
   ): Observable<PageDto<DeliverySummaryDto>> {
     return this.list(query);
+  }
+
+  getCustomerHistorySummary(): Observable<CustomerHistorySummaryDto> {
+    return this.httpClient.get<CustomerHistorySummaryDto>(
+      `${this.baseUrl}/deliveries/history/summary`,
+    );
   }
 
   getById(id: string): Observable<DeliveryDetailDto> {

--- a/frontend/src/app/core/services/enum/delivery.types.ts
+++ b/frontend/src/app/core/services/enum/delivery.types.ts
@@ -6,6 +6,13 @@ export interface PageDto<T> {
   number: number;
 }
 
+export interface CustomerHistorySummaryDto {
+  totalDeliveries: number;
+  deliveredDeliveries: number;
+  totalSpent: number;
+  totalSpentCurrency: string;
+}
+
 export interface DeliverySummaryDto {
   id: string;
   trackingCode?: string | null;

--- a/frontend/src/app/features/customer/customer.routes.ts
+++ b/frontend/src/app/features/customer/customer.routes.ts
@@ -68,7 +68,7 @@ export const customerRoutes: Routes = [
       ),
     data: {
       pageTitle: 'Delivery History',
-      subtitle: 'View and manage your completed deliveries',
+      subtitle: 'View and manage your delivery history',
     },
   },
   {

--- a/frontend/src/app/features/customer/customer.routes.ts
+++ b/frontend/src/app/features/customer/customer.routes.ts
@@ -62,8 +62,14 @@ export const customerRoutes: Routes = [
   },
   {
     path: 'history',
-    loadComponent: loadStub,
-    data: { pageTitle: 'History' },
+    loadComponent: () =>
+      import('./pages/history/customer-history').then(
+        (m) => m.CustomerHistoryPage,
+      ),
+    data: {
+      pageTitle: 'Delivery History',
+      subtitle: 'View and manage your completed deliveries',
+    },
   },
   {
     path: 'notifications',

--- a/frontend/src/app/features/customer/pages/history/customer-history.html
+++ b/frontend/src/app/features/customer/pages/history/customer-history.html
@@ -12,7 +12,7 @@
       <article
         class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-6 py-5 shadow-(--p-shadow-xs)"
       >
-        <p class="text-[13px] text-p-text-muted">Completed</p>
+        <p class="text-[13px] text-p-text-muted">Delivered</p>
         <p class="mt-2 text-[32px] leading-none font-semibold text-emerald-600">
           {{ completedDeliveries() }}
         </p>
@@ -57,7 +57,7 @@
             [class.text-p-text-secondary]="!isStatusFilterActive('completed')"
             (click)="setStatusFilter('completed')"
           >
-            Completed
+            Delivered
           </button>
         </div>
       </div>
@@ -90,16 +90,17 @@
         </div>
       } @else {
         <p-table
-          [value]="filteredRows()"
+          [value]="rows()"
+          [lazy]="true"
           [paginator]="true"
           [rows]="rowsPerPage"
           [first]="pageFirst()"
-          [totalRecords]="filteredRows().length"
+          [totalRecords]="totalRecords()"
           dataKey="id"
           responsiveLayout="scroll"
           size="small"
           styleClass="delivery-list-table"
-          (onPage)="onPageChange($event)"
+          (onLazyLoad)="onLazyLoad($event)"
         >
           <ng-template #header>
             <tr class="border-b border-p-surface-border bg-p-surface-ground">
@@ -159,7 +160,7 @@
               <td colspan="6">
                 <app-table-empty-state
                   title="No deliveries found"
-                  message="Try a different status/date filter."
+                  message="Try a different status filter."
                   icon="pi pi-history"
                 />
               </td>

--- a/frontend/src/app/features/customer/pages/history/customer-history.html
+++ b/frontend/src/app/features/customer/pages/history/customer-history.html
@@ -1,0 +1,173 @@
+<div class="flex min-h-0 flex-1 flex-col bg-p-surface-ground">
+  <div class="mx-auto w-full max-w-[1040px] space-y-4 p-5">
+    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      <article
+        class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-6 py-5 shadow-(--p-shadow-xs)"
+      >
+        <p class="text-[13px] text-p-text-muted">Total Deliveries</p>
+        <p class="mt-2 text-[32px] leading-none font-semibold text-p-text-primary">
+          {{ totalDeliveries() }}
+        </p>
+      </article>
+      <article
+        class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-6 py-5 shadow-(--p-shadow-xs)"
+      >
+        <p class="text-[13px] text-p-text-muted">Completed</p>
+        <p class="mt-2 text-[32px] leading-none font-semibold text-emerald-600">
+          {{ completedDeliveries() }}
+        </p>
+      </article>
+      <article
+        class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-6 py-5 shadow-(--p-shadow-xs)"
+      >
+        <p class="text-[13px] text-p-text-muted">Total Spent</p>
+        <p class="mt-2 text-[32px] leading-none font-semibold text-blue-600">
+          {{ totalSpent() | currency: spendCurrency() : 'symbol' : '1.2-2' }}
+        </p>
+      </article>
+    </section>
+
+    <section
+      class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-3 shadow-(--p-shadow-xs)"
+    >
+      <div class="flex items-center gap-3">
+        <p class="text-sm font-medium text-p-text-muted">Filter:</p>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="rounded-full border px-4 py-1.5 text-sm font-medium transition-colors"
+            [class.border-blue-500]="isStatusFilterActive('all')"
+            [class.bg-blue-500]="isStatusFilterActive('all')"
+            [class.text-white]="isStatusFilterActive('all')"
+            [class.border-p-surface-border]="!isStatusFilterActive('all')"
+            [class.bg-p-surface-ground]="!isStatusFilterActive('all')"
+            [class.text-p-text-secondary]="!isStatusFilterActive('all')"
+            (click)="setStatusFilter('all')"
+          >
+            All
+          </button>
+          <button
+            type="button"
+            class="rounded-full border px-4 py-1.5 text-sm font-medium transition-colors"
+            [class.border-blue-500]="isStatusFilterActive('completed')"
+            [class.bg-blue-500]="isStatusFilterActive('completed')"
+            [class.text-white]="isStatusFilterActive('completed')"
+            [class.border-p-surface-border]="!isStatusFilterActive('completed')"
+            [class.bg-p-surface-ground]="!isStatusFilterActive('completed')"
+            [class.text-p-text-secondary]="!isStatusFilterActive('completed')"
+            (click)="setStatusFilter('completed')"
+          >
+            Completed
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card shadow-(--p-shadow-xs)">
+      @if (loading()) {
+        <div class="px-4 py-3">
+          <table class="w-full">
+            <tbody>
+              @for (_row of loadingSkeletonRows; track _row) {
+                <tr>
+                  <td class="py-2"><p-skeleton width="6rem" height="1rem" /></td>
+                  <td class="py-2"><p-skeleton width="7rem" height="1rem" /></td>
+                  <td class="py-2"><p-skeleton width="10rem" height="1rem" /></td>
+                  <td class="py-2"><p-skeleton width="10rem" height="1rem" /></td>
+                  <td class="py-2"><p-skeleton width="6rem" height="1rem" /></td>
+                  <td class="py-2"><p-skeleton width="5rem" height="1rem" /></td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else if (loadError(); as errorText) {
+        <div class="p-5">
+          <p class="text-sm font-semibold text-red-700">{{ errorText }}</p>
+          <div class="mt-3">
+            <p-button label="Retry" icon="pi pi-refresh" (onClick)="retry()" />
+          </div>
+        </div>
+      } @else {
+        <p-table
+          [value]="filteredRows()"
+          [paginator]="true"
+          [rows]="rowsPerPage"
+          [first]="pageFirst()"
+          [totalRecords]="filteredRows().length"
+          dataKey="id"
+          responsiveLayout="scroll"
+          size="small"
+          styleClass="delivery-list-table"
+          (onPage)="onPageChange($event)"
+        >
+          <ng-template #header>
+            <tr class="border-b border-p-surface-border bg-p-surface-ground">
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Delivery ID
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Date
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Pickup Location
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Destination
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Status
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Amount
+              </th>
+            </tr>
+          </ng-template>
+
+          <ng-template #body let-delivery>
+            <tr
+              class="cursor-pointer text-sm text-p-text-secondary transition-colors hover:bg-p-surface-hover"
+              role="link"
+              tabindex="0"
+              (click)="openDeliveryDetails(delivery.id)"
+              (keydown.enter)="openDeliveryDetails(delivery.id)"
+              (keydown.space)="$event.preventDefault(); openDeliveryDetails(delivery.id)"
+            >
+              <td class="w-36 px-4 py-3.5 align-top text-[12px] font-semibold text-blue-600 uppercase">
+                {{ delivery.shortId }}
+              </td>
+              <td class="w-40 px-4 py-3.5 align-top text-[13px] text-p-text-primary">
+                {{ delivery.createdAt | date: 'mediumDate' }}
+              </td>
+              <td class="min-w-56 px-4 py-3.5 align-top text-[13px] text-p-text-primary">
+                {{ delivery.pickup }}
+              </td>
+              <td class="min-w-56 px-4 py-3.5 align-top text-[13px] text-p-text-primary">
+                {{ delivery.destination }}
+              </td>
+              <td class="w-36 px-4 py-3.5 align-top">
+                <app-status-tag [status]="delivery.status" size="sm" />
+              </td>
+              <td class="w-32 px-4 py-3.5 align-top text-[13px] font-semibold text-p-text-primary">
+                {{ delivery.amount | currency: delivery.currency : 'symbol' : '1.2-2' }}
+              </td>
+            </tr>
+          </ng-template>
+
+          <ng-template #emptymessage>
+            <tr>
+              <td colspan="6">
+                <app-table-empty-state
+                  title="No deliveries found"
+                  message="Try a different status/date filter."
+                  icon="pi pi-history"
+                />
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+
+      }
+    </section>
+  </div>
+</div>

--- a/frontend/src/app/features/customer/pages/history/customer-history.ts
+++ b/frontend/src/app/features/customer/pages/history/customer-history.ts
@@ -1,0 +1,224 @@
+import { CurrencyPipe, DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { DeliveryService } from '@core/services/delivery/delivery';
+import {
+  DeliverySummaryDto,
+  PageDto,
+} from '@core/services/enum/delivery.types';
+import { StatusTagComponent, TableEmptyStateComponent } from '@shared/ui/public-api';
+import { Button } from 'primeng/button';
+import { Skeleton } from 'primeng/skeleton';
+import { TableModule } from 'primeng/table';
+import { catchError, finalize, forkJoin, map, of, switchMap } from 'rxjs';
+
+type HistoryStatusFilter = 'all' | 'completed';
+
+interface CustomerHistoryRow {
+  id: string;
+  shortId: string;
+  status: string;
+  createdAt: string;
+  pickup: string;
+  destination: string;
+  amount: number;
+  currency: string;
+}
+
+@Component({
+  selector: 'app-customer-history-page',
+  imports: [
+    CurrencyPipe,
+    DatePipe,
+    TableModule,
+    Button,
+    Skeleton,
+    StatusTagComponent,
+    TableEmptyStateComponent,
+  ],
+  templateUrl: './customer-history.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomerHistoryPage {
+  private static readonly PAGE_SIZE = 8;
+  private static readonly FETCH_PAGE_SIZE = 200;
+
+  private readonly deliveryService = inject(DeliveryService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
+
+  protected readonly loading = signal(false);
+  protected readonly loadError = signal<string | null>(null);
+  protected readonly statusFilter = signal<HistoryStatusFilter>('all');
+
+  protected readonly pageFirst = signal(0);
+  protected readonly rowsPerPage = CustomerHistoryPage.PAGE_SIZE;
+  protected readonly loadingSkeletonRows = [0, 1, 2, 3];
+
+  private readonly allRows = signal<CustomerHistoryRow[]>([]);
+
+  protected readonly filteredRows = computed(() =>
+    this.allRows().filter((row) => this.matchesStatusFilter(row.status)),
+  );
+
+  protected readonly totalDeliveries = computed(() => this.allRows().length);
+  protected readonly completedDeliveries = computed(
+    () =>
+      this.allRows().filter((row) => this.normalizeStatus(row.status) === 'DELIVERED')
+        .length,
+  );
+  protected readonly totalSpent = computed(() =>
+    this.allRows()
+      .filter((row) => this.normalizeStatus(row.status) === 'DELIVERED')
+      .reduce((sum, row) => sum + row.amount, 0),
+  );
+  protected readonly spendCurrency = computed(() => {
+    const delivered = this.allRows().find(
+      (row) => this.normalizeStatus(row.status) === 'DELIVERED',
+    );
+    return delivered?.currency ?? 'RON';
+  });
+
+  protected readonly showingStart = computed(() =>
+    this.filteredRows().length === 0 ? 0 : this.pageFirst() + 1,
+  );
+  protected readonly showingEnd = computed(() =>
+    Math.min(this.pageFirst() + this.rowsPerPage, this.filteredRows().length),
+  );
+
+  constructor() {
+    this.loadHistoryData();
+  }
+
+  protected setStatusFilter(filter: HistoryStatusFilter): void {
+    if (this.statusFilter() === filter) {
+      return;
+    }
+    this.statusFilter.set(filter);
+    this.pageFirst.set(0);
+  }
+
+  protected isStatusFilterActive(filter: HistoryStatusFilter): boolean {
+    return this.statusFilter() === filter;
+  }
+
+  protected onPageChange(event: { first?: number }): void {
+    this.pageFirst.set(typeof event.first === 'number' ? event.first : 0);
+  }
+
+  protected openDeliveryDetails(deliveryId: string): void {
+    void this.router.navigate(['/customer/delivery', deliveryId]);
+  }
+
+  protected retry(): void {
+    this.loadHistoryData();
+  }
+
+  private loadHistoryData(): void {
+    this.loading.set(true);
+    this.loadError.set(null);
+
+    this.deliveryService
+      .listForCurrentCustomer({
+        page: 0,
+        size: CustomerHistoryPage.FETCH_PAGE_SIZE,
+        sort: 'createdAt,desc',
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        switchMap((firstPage) => this.loadAllPages(firstPage)),
+        map((deliveries) => deliveries.map((delivery) => this.mapRow(delivery))),
+        catchError(() => {
+          this.loadError.set('Could not load delivery history. Please retry.');
+          return of([] as CustomerHistoryRow[]);
+        }),
+        finalize(() => this.loading.set(false)),
+      )
+      .subscribe((rows) => {
+        this.allRows.set(rows);
+        this.pageFirst.set(0);
+      });
+  }
+
+  private loadAllPages(
+    firstPage: PageDto<DeliverySummaryDto>,
+  ) {
+    const firstContent = Array.isArray(firstPage.content) ? firstPage.content : [];
+    const totalPages =
+      typeof firstPage.totalPages === 'number' && firstPage.totalPages > 0
+        ? firstPage.totalPages
+        : 1;
+
+    if (totalPages <= 1) {
+      return of(firstContent);
+    }
+
+    const remainingRequests = Array.from({ length: totalPages - 1 }, (_unused, index) =>
+      this.deliveryService
+        .listForCurrentCustomer({
+          page: index + 1,
+          size: CustomerHistoryPage.FETCH_PAGE_SIZE,
+          sort: 'createdAt,desc',
+        })
+        .pipe(
+          map((response) =>
+            Array.isArray(response.content) ? response.content : ([] as DeliverySummaryDto[]),
+          ),
+          catchError(() => of([] as DeliverySummaryDto[])),
+        ),
+    );
+
+    return forkJoin(remainingRequests).pipe(
+      map((remainingPages) => [firstContent, ...remainingPages].flat()),
+    );
+  }
+
+  private mapRow(delivery: DeliverySummaryDto): CustomerHistoryRow {
+    return {
+      id: delivery.id,
+      shortId: this.toShortId(delivery),
+      status: delivery.status ?? 'CREATED',
+      createdAt: delivery.createdAt,
+      pickup: this.toDisplayAddress(delivery.pickupLine1),
+      destination: this.toDisplayAddress(delivery.destinationLine1),
+      amount: Number.isFinite(delivery.totalAmount) ? delivery.totalAmount : 0,
+      currency: delivery.currency?.trim() || 'RON',
+    };
+  }
+
+  private toShortId(delivery: DeliverySummaryDto): string {
+    const tracking = delivery.trackingCode?.trim();
+    if (tracking) {
+      return tracking;
+    }
+    const raw = delivery.id.replaceAll('-', '').toUpperCase().slice(0, 6);
+    return `DLV-${raw || '000000'}`;
+  }
+
+  private toDisplayAddress(value: string | null | undefined): string {
+    const normalized = value?.trim();
+    return normalized && normalized.length > 0 ? normalized : '-';
+  }
+
+  private matchesStatusFilter(statusRaw: string): boolean {
+    const status = this.normalizeStatus(statusRaw);
+    switch (this.statusFilter()) {
+      case 'completed':
+        return status === 'DELIVERED';
+      default:
+        return true;
+    }
+  }
+
+  private normalizeStatus(status: string): string {
+    return status.trim().toUpperCase();
+  }
+}

--- a/frontend/src/app/features/customer/pages/history/customer-history.ts
+++ b/frontend/src/app/features/customer/pages/history/customer-history.ts
@@ -2,7 +2,6 @@ import { CurrencyPipe, DatePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   computed,
   inject,
   signal,
@@ -11,14 +10,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { DeliveryService } from '@core/services/delivery/delivery';
 import {
+  CustomerHistorySummaryDto,
   DeliverySummaryDto,
-  PageDto,
 } from '@core/services/enum/delivery.types';
 import { StatusTagComponent, TableEmptyStateComponent } from '@shared/ui/public-api';
 import { Button } from 'primeng/button';
 import { Skeleton } from 'primeng/skeleton';
-import { TableModule } from 'primeng/table';
-import { catchError, finalize, forkJoin, map, of, switchMap } from 'rxjs';
+import { TableLazyLoadEvent, TableModule } from 'primeng/table';
+import { catchError, finalize, of } from 'rxjs';
 
 type HistoryStatusFilter = 'all' | 'completed';
 
@@ -49,10 +48,14 @@ interface CustomerHistoryRow {
 })
 export class CustomerHistoryPage {
   private static readonly PAGE_SIZE = 8;
-  private static readonly FETCH_PAGE_SIZE = 200;
+  private static readonly DEFAULT_SUMMARY: CustomerHistorySummaryDto = {
+    totalDeliveries: 0,
+    deliveredDeliveries: 0,
+    totalSpent: 0,
+    totalSpentCurrency: 'RON',
+  };
 
   private readonly deliveryService = inject(DeliveryService);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
 
   protected readonly loading = signal(false);
@@ -62,39 +65,26 @@ export class CustomerHistoryPage {
   protected readonly pageFirst = signal(0);
   protected readonly rowsPerPage = CustomerHistoryPage.PAGE_SIZE;
   protected readonly loadingSkeletonRows = [0, 1, 2, 3];
+  protected readonly rows = signal<CustomerHistoryRow[]>([]);
+  protected readonly totalRecords = signal(0);
 
-  private readonly allRows = signal<CustomerHistoryRow[]>([]);
-
-  protected readonly filteredRows = computed(() =>
-    this.allRows().filter((row) => this.matchesStatusFilter(row.status)),
+  private readonly summary = signal<CustomerHistorySummaryDto>(
+    CustomerHistoryPage.DEFAULT_SUMMARY,
   );
 
-  protected readonly totalDeliveries = computed(() => this.allRows().length);
+  protected readonly totalDeliveries = computed(
+    () => this.summary().totalDeliveries,
+  );
   protected readonly completedDeliveries = computed(
-    () =>
-      this.allRows().filter((row) => this.normalizeStatus(row.status) === 'DELIVERED')
-        .length,
+    () => this.summary().deliveredDeliveries,
   );
-  protected readonly totalSpent = computed(() =>
-    this.allRows()
-      .filter((row) => this.normalizeStatus(row.status) === 'DELIVERED')
-      .reduce((sum, row) => sum + row.amount, 0),
-  );
-  protected readonly spendCurrency = computed(() => {
-    const delivered = this.allRows().find(
-      (row) => this.normalizeStatus(row.status) === 'DELIVERED',
-    );
-    return delivered?.currency ?? 'RON';
-  });
-
-  protected readonly showingStart = computed(() =>
-    this.filteredRows().length === 0 ? 0 : this.pageFirst() + 1,
-  );
-  protected readonly showingEnd = computed(() =>
-    Math.min(this.pageFirst() + this.rowsPerPage, this.filteredRows().length),
+  protected readonly totalSpent = computed(() => this.summary().totalSpent);
+  protected readonly spendCurrency = computed(
+    () => this.summary().totalSpentCurrency || 'RON',
   );
 
   constructor() {
+    this.loadSummary();
     this.loadHistoryData();
   }
 
@@ -104,14 +94,20 @@ export class CustomerHistoryPage {
     }
     this.statusFilter.set(filter);
     this.pageFirst.set(0);
+    this.loadHistoryData(0, this.rowsPerPage);
   }
 
   protected isStatusFilterActive(filter: HistoryStatusFilter): boolean {
     return this.statusFilter() === filter;
   }
 
-  protected onPageChange(event: { first?: number }): void {
-    this.pageFirst.set(typeof event.first === 'number' ? event.first : 0);
+  protected onLazyLoad(event: TableLazyLoadEvent): void {
+    const first = typeof event.first === 'number' ? event.first : this.pageFirst();
+    const rows = typeof event.rows === 'number' && event.rows > 0
+      ? event.rows
+      : this.rowsPerPage;
+    this.pageFirst.set(first);
+    this.loadHistoryData(Math.floor(first / rows), rows);
   }
 
   protected openDeliveryDetails(deliveryId: string): void {
@@ -119,66 +115,54 @@ export class CustomerHistoryPage {
   }
 
   protected retry(): void {
-    this.loadHistoryData();
+    this.loadSummary();
+    this.loadHistoryData(Math.floor(this.pageFirst() / this.rowsPerPage), this.rowsPerPage);
   }
 
-  private loadHistoryData(): void {
+  private loadSummary(): void {
+    this.deliveryService
+      .getCustomerHistorySummary()
+      .pipe(
+        takeUntilDestroyed(),
+        catchError(() => of(CustomerHistoryPage.DEFAULT_SUMMARY)),
+      )
+      .subscribe((summary) => {
+        this.summary.set({
+          totalDeliveries: this.toNonNegative(summary.totalDeliveries),
+          deliveredDeliveries: this.toNonNegative(summary.deliveredDeliveries),
+          totalSpent: this.toNonNegative(summary.totalSpent),
+          totalSpentCurrency: this.toCurrency(summary.totalSpentCurrency),
+        });
+      });
+  }
+
+  private loadHistoryData(page = 0, size = this.rowsPerPage): void {
     this.loading.set(true);
     this.loadError.set(null);
 
     this.deliveryService
       .listForCurrentCustomer({
-        page: 0,
-        size: CustomerHistoryPage.FETCH_PAGE_SIZE,
+        page,
+        size,
         sort: 'createdAt,desc',
+        status: this.statusFilter() === 'completed' ? 'DELIVERED' : undefined,
       })
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        switchMap((firstPage) => this.loadAllPages(firstPage)),
-        map((deliveries) => deliveries.map((delivery) => this.mapRow(delivery))),
+        takeUntilDestroyed(),
         catchError(() => {
           this.loadError.set('Could not load delivery history. Please retry.');
-          return of([] as CustomerHistoryRow[]);
+          return of({
+            content: [] as DeliverySummaryDto[],
+            totalElements: 0,
+          });
         }),
         finalize(() => this.loading.set(false)),
       )
-      .subscribe((rows) => {
-        this.allRows.set(rows);
-        this.pageFirst.set(0);
+      .subscribe((response) => {
+        const deliveries = Array.isArray(response.content) ? response.content : [];
+        this.rows.set(deliveries.map((delivery) => this.mapRow(delivery)));
+        this.totalRecords.set(this.toNonNegative(response.totalElements));
       });
-  }
-
-  private loadAllPages(
-    firstPage: PageDto<DeliverySummaryDto>,
-  ) {
-    const firstContent = Array.isArray(firstPage.content) ? firstPage.content : [];
-    const totalPages =
-      typeof firstPage.totalPages === 'number' && firstPage.totalPages > 0
-        ? firstPage.totalPages
-        : 1;
-
-    if (totalPages <= 1) {
-      return of(firstContent);
-    }
-
-    const remainingRequests = Array.from({ length: totalPages - 1 }, (_unused, index) =>
-      this.deliveryService
-        .listForCurrentCustomer({
-          page: index + 1,
-          size: CustomerHistoryPage.FETCH_PAGE_SIZE,
-          sort: 'createdAt,desc',
-        })
-        .pipe(
-          map((response) =>
-            Array.isArray(response.content) ? response.content : ([] as DeliverySummaryDto[]),
-          ),
-          catchError(() => of([] as DeliverySummaryDto[])),
-        ),
-    );
-
-    return forkJoin(remainingRequests).pipe(
-      map((remainingPages) => [firstContent, ...remainingPages].flat()),
-    );
   }
 
   private mapRow(delivery: DeliverySummaryDto): CustomerHistoryRow {
@@ -208,17 +192,16 @@ export class CustomerHistoryPage {
     return normalized && normalized.length > 0 ? normalized : '-';
   }
 
-  private matchesStatusFilter(statusRaw: string): boolean {
-    const status = this.normalizeStatus(statusRaw);
-    switch (this.statusFilter()) {
-      case 'completed':
-        return status === 'DELIVERED';
-      default:
-        return true;
+  private toNonNegative(value: unknown): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return 0;
     }
+    return Math.max(0, value);
   }
 
-  private normalizeStatus(status: string): string {
-    return status.trim().toUpperCase();
+  private toCurrency(value: unknown): string {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value.trim().toUpperCase()
+      : 'RON';
   }
 }


### PR DESCRIPTION
This pull request introduces a new "Delivery History" feature for customers in the frontend, providing a dedicated page to view and manage completed deliveries. It also includes several backend improvements to support this feature, such as changes to SQL queries and entity mappings for delivery status. The most significant changes are grouped below:

**Frontend: Customer Delivery History Feature**
* Added a new `CustomerHistoryPage` component (`customer-history.ts`, `customer-history.html`) that displays a paginated, filterable table of the customer's deliveries, including summary statistics (total deliveries, completed, total spent) and filtering options. The page handles loading states, errors, and navigation to delivery details. 
* Updated the customer routes to load the new history page and improved the route's metadata (title, subtitle).

**Backend: Query and Entity Mapping Improvements**
* Updated the `Delivery` and `DeliveryStatusHistory` entities to specify the `columnDefinition` for the `status` column as `delivery_status`, ensuring correct mapping to the database enum type. 
* Refactored several repository queries (`DeliveryRepository.java`) to use native SQL, referencing the correct table and column names and explicitly casting to the `delivery_status` enum. This affects methods for aggregating customer orders and spend, calculating total revenue, and finding revenue currencies.