### PR TITLE
Earnings summary + entries API + Earnings page with chart (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+thesis-results/

--- a/backend/README.md
+++ b/backend/README.md
@@ -237,3 +237,36 @@ Shared query contract:
 - optional `granularity=day|week` (defaults to `day`)
 - UTC-normalized aggregation buckets on the backend
 - max window enforced to `180` days (validation error when exceeded)
+
+## Courier earnings APIs (`#58`)
+
+Courier-only earnings visibility endpoints are available under `/api/couriers/me/earnings`:
+
+- `GET /summary`
+- `GET /entries`
+
+The current MVP uses a **derived** earnings model (no dedicated ledger table yet):
+
+- earning entries are derived from `DELIVERED` rows in `delivery_status_history` joined with `deliveries`
+- entry timestamp is `delivery_status_history.recorded_at` (UTC semantics)
+- amount source is `deliveries.total_amount`
+
+Shared query semantics:
+
+- optional `from` and `to` (`ISO-8601` timestamp or `YYYY-MM-DD`)
+- when provided, `from` and `to` must be sent together
+- max range is `180` days
+- range boundaries are interpreted in UTC (date-only `to` is treated as end-of-day exclusive)
+
+Summary payload includes:
+
+- `todayTotal`, `weekTotal`, `monthTotal`
+- `customRangeTotal` and `trend` (vs previous period with same span)
+- UTC `window` metadata and daily chart buckets (`chartPoints`)
+- `currency` (dominant delivered currency for the selected window, fallback `RON`)
+
+Entries payload:
+
+- paginated rows with deterministic default sort (`recordedAt,desc`)
+- fields: `deliveryId`, `trackingCode`, `amount`, `currency`, `status`, `earnedAt`, optional `note`
+- no customer-sensitive fields are exposed

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/CourierEarningsDefaults.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/CourierEarningsDefaults.java
@@ -1,0 +1,12 @@
+package com.ubb.deliveryhub.courier;
+
+public final class CourierEarningsDefaults {
+
+    public static final int PAGE_SIZE = 20;
+    public static final String SORT_PROPERTY = "recordedAt";
+    public static final long MAX_RANGE_DAYS = 180;
+    public static final String TIMEZONE = "UTC";
+
+    private CourierEarningsDefaults() {
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/CourierEarningsController.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/CourierEarningsController.java
@@ -1,0 +1,49 @@
+package com.ubb.deliveryhub.courier.api;
+
+import com.ubb.deliveryhub.courier.CourierEarningsDefaults;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsEntryDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsQueryDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsSummaryDto;
+import com.ubb.deliveryhub.courier.service.CourierEarningsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/couriers/me/earnings")
+public class CourierEarningsController {
+
+    private final CourierEarningsService courierEarningsService;
+
+    @GetMapping("/summary")
+    @PreAuthorize("hasRole('COURIER')")
+    public CourierEarningsSummaryDto getSummary(
+        Authentication authentication,
+        @ModelAttribute CourierEarningsQueryDto query
+    ) {
+        return courierEarningsService.getSummary(authentication, query);
+    }
+
+    @GetMapping("/entries")
+    @PreAuthorize("hasRole('COURIER')")
+    public Page<CourierEarningsEntryDto> getEntries(
+        Authentication authentication,
+        @ModelAttribute CourierEarningsQueryDto query,
+        @PageableDefault(
+            size = CourierEarningsDefaults.PAGE_SIZE,
+            sort = CourierEarningsDefaults.SORT_PROPERTY,
+            direction = Sort.Direction.DESC
+        ) Pageable pageable
+    ) {
+        return courierEarningsService.getEntries(authentication, query, pageable);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/CourierEarningsExceptionHandler.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/CourierEarningsExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.ubb.deliveryhub.courier.api;
+
+import com.ubb.deliveryhub.courier.domain.exception.CourierEarningsValidationException;
+import com.ubb.deliveryhub.courier.domain.exception.InvalidCourierEarningsSortException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = CourierEarningsController.class)
+public class CourierEarningsExceptionHandler {
+
+    @ExceptionHandler(CourierEarningsValidationException.class)
+    public ResponseEntity<ProblemDetail> handleValidation(CourierEarningsValidationException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setProperty("errors", ex.getErrors());
+        pd.setProperty("code", "COURIER_EARNINGS_VALIDATION_ERROR");
+        return ResponseEntity.badRequest().body(pd);
+    }
+
+    @ExceptionHandler(InvalidCourierEarningsSortException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidSort(InvalidCourierEarningsSortException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        pd.setProperty("invalidSortProperty", ex.getInvalidProperty());
+        pd.setProperty("allowedSortProperties", ex.getAllowedProperties());
+        pd.setProperty("code", "COURIER_EARNINGS_SORT_ERROR");
+        return ResponseEntity.badRequest().body(pd);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsChartPointDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsChartPointDto.java
@@ -1,0 +1,15 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Value
+@Builder
+public class CourierEarningsChartPointDto {
+    Instant bucketStart;
+    Instant bucketEnd;
+    BigDecimal total;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsEntryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsEntryDto.java
@@ -1,0 +1,22 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Value
+@Builder
+public class CourierEarningsEntryDto {
+    UUID deliveryId;
+    String trackingCode;
+    BigDecimal amount;
+    String currency;
+    DeliveryStatus status;
+    Instant earnedAt;
+    String category;
+    String note;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsQueryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsQueryDto.java
@@ -1,0 +1,12 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CourierEarningsQueryDto {
+
+    private String from;
+    private String to;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsSummaryDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsSummaryDto.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Value
+@Builder
+public class CourierEarningsSummaryDto {
+    String currency;
+    BigDecimal todayTotal;
+    BigDecimal weekTotal;
+    BigDecimal monthTotal;
+    BigDecimal customRangeTotal;
+    CourierEarningsTrendDto trend;
+    CourierEarningsWindowDto window;
+    List<CourierEarningsChartPointDto> chartPoints;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsTrendDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsTrendDto.java
@@ -1,0 +1,14 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Value
+@Builder
+public class CourierEarningsTrendDto {
+    BigDecimal previousPeriodTotal;
+    BigDecimal deltaAmount;
+    BigDecimal deltaPercent;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsWindowDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsWindowDto.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 public class CourierEarningsWindowDto {
     Instant from;
     Instant to;
+    Instant toExclusive;
     String timezone;
     long maxRangeDays;
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsWindowDto.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/api/dto/earnings/CourierEarningsWindowDto.java
@@ -1,0 +1,15 @@
+package com.ubb.deliveryhub.courier.api.dto.earnings;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class CourierEarningsWindowDto {
+    Instant from;
+    Instant to;
+    String timezone;
+    long maxRangeDays;
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/domain/exception/CourierEarningsValidationException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/domain/exception/CourierEarningsValidationException.java
@@ -1,0 +1,18 @@
+package com.ubb.deliveryhub.courier.domain.exception;
+
+import java.util.List;
+import java.util.Map;
+
+public class CourierEarningsValidationException extends RuntimeException {
+
+    private final Map<String, List<String>> errors;
+
+    public CourierEarningsValidationException(String message, Map<String, List<String>> errors) {
+        super(message);
+        this.errors = errors;
+    }
+
+    public Map<String, List<String>> getErrors() {
+        return errors;
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/domain/exception/InvalidCourierEarningsSortException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/domain/exception/InvalidCourierEarningsSortException.java
@@ -1,0 +1,26 @@
+package com.ubb.deliveryhub.courier.domain.exception;
+
+import java.util.Set;
+
+public class InvalidCourierEarningsSortException extends RuntimeException {
+
+    private final String invalidProperty;
+    private final Set<String> allowedProperties;
+
+    public InvalidCourierEarningsSortException(String invalidProperty, Set<String> allowedProperties) {
+        super(
+            "Unsupported courier earnings sort property '%s'. Allowed: %s"
+                .formatted(invalidProperty, String.join(", ", allowedProperties))
+        );
+        this.invalidProperty = invalidProperty;
+        this.allowedProperties = Set.copyOf(allowedProperties);
+    }
+
+    public String getInvalidProperty() {
+        return invalidProperty;
+    }
+
+    public Set<String> getAllowedProperties() {
+        return allowedProperties;
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/service/CourierEarningsService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/service/CourierEarningsService.java
@@ -9,6 +9,7 @@ import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsTrendDto;
 import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsWindowDto;
 import com.ubb.deliveryhub.courier.domain.exception.CourierEarningsValidationException;
 import com.ubb.deliveryhub.courier.domain.exception.InvalidCourierEarningsSortException;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import com.ubb.deliveryhub.delivery.repository.CourierEarningEntryView;
 import com.ubb.deliveryhub.delivery.repository.DeliveryStatusHistoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -76,6 +77,7 @@ public class CourierEarningsService {
         List<CourierEarningsChartPointDto> chartPoints = toChartPoints(
             deliveryStatusHistoryRepository.findDeliveredEarningsEntriesInWindow(
                 courierId,
+                DeliveryStatus.DELIVERED,
                 currency,
                 customWindow.fromInclusive(),
                 customWindow.toExclusive()
@@ -96,7 +98,8 @@ public class CourierEarningsService {
                 .build())
             .window(CourierEarningsWindowDto.builder()
                 .from(customWindow.fromInclusive())
-                .to(customWindow.toExclusive())
+                .to(toInclusiveInstant(customWindow.toExclusive()))
+                .toExclusive(customWindow.toExclusive())
                 .timezone(CourierEarningsDefaults.TIMEZONE)
                 .maxRangeDays(CourierEarningsDefaults.MAX_RANGE_DAYS)
                 .build())
@@ -125,12 +128,14 @@ public class CourierEarningsService {
         if (window.fromInclusive() == null || window.toExclusive() == null) {
             return deliveryStatusHistoryRepository.findDeliveredEarningsEntriesForCourier(
                 courierId,
+                DeliveryStatus.DELIVERED,
                 currency,
                 effectivePage
             ).map(this::toEntryDto);
         }
         return deliveryStatusHistoryRepository.findDeliveredEarningsEntriesForCourier(
             courierId,
+            DeliveryStatus.DELIVERED,
             currency,
             window.fromInclusive(),
             window.toExclusive(),
@@ -154,8 +159,8 @@ public class CourierEarningsService {
     private List<CourierEarningsChartPointDto> toChartPoints(List<CourierEarningEntryView> entries, Window window) {
         Map<LocalDate, BigDecimal> totals = new LinkedHashMap<>();
         LocalDate dateCursor = toUtcDate(window.fromInclusive());
-        LocalDate toExclusiveDate = toUtcDate(window.toExclusive());
-        while (dateCursor.isBefore(toExclusiveDate)) {
+        LocalDate toInclusiveDate = toUtcDate(toInclusiveInstant(window.toExclusive()));
+        while (!dateCursor.isAfter(toInclusiveDate)) {
             totals.put(dateCursor, BigDecimal.ZERO);
             dateCursor = dateCursor.plusDays(1);
         }
@@ -186,16 +191,23 @@ public class CourierEarningsService {
     private String resolveCurrency(UUID courierId, Instant fromInclusive, Instant toExclusive) {
         List<String> currencies;
         if (fromInclusive == null || toExclusive == null) {
-            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(courierId);
+            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(
+                courierId,
+                DeliveryStatus.DELIVERED
+            );
         } else {
             currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(
                 courierId,
+                DeliveryStatus.DELIVERED,
                 fromInclusive,
                 toExclusive
             );
         }
         if (currencies.isEmpty()) {
-            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(courierId);
+            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(
+                courierId,
+                DeliveryStatus.DELIVERED
+            );
         }
         if (currencies.isEmpty()) {
             return "RON";
@@ -207,6 +219,7 @@ public class CourierEarningsService {
     private BigDecimal sumWindow(UUID courierId, String currency, Window window) {
         BigDecimal total = deliveryStatusHistoryRepository.sumDeliveredEarningsByCourierAndCurrencyInWindow(
             courierId,
+            DeliveryStatus.DELIVERED,
             currency,
             window.fromInclusive(),
             window.toExclusive()
@@ -318,14 +331,12 @@ public class CourierEarningsService {
 
     private Instant parseBoundary(String raw, String fieldName, boolean toExclusiveForDateOnly) {
         try {
-            Instant parsed = Instant.parse(raw);
-            return toExclusiveForDateOnly ? parsed.plusNanos(1) : parsed;
+            return Instant.parse(raw);
         } catch (DateTimeParseException ignored) {
             // fallback
         }
         try {
-            Instant parsed = OffsetDateTime.parse(raw).toInstant();
-            return toExclusiveForDateOnly ? parsed.plusNanos(1) : parsed;
+            return OffsetDateTime.parse(raw).toInstant();
         } catch (DateTimeParseException ignored) {
             // fallback
         }
@@ -354,6 +365,13 @@ public class CourierEarningsService {
 
     private static Instant dayStart(Instant point) {
         return toUtcDate(point).atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
+
+    private static Instant toInclusiveInstant(Instant toExclusive) {
+        if (toExclusive == null) {
+            return null;
+        }
+        return toExclusive.minusNanos(1);
     }
 
     private static LocalDate toUtcDate(Instant point) {

--- a/backend/src/main/java/com/ubb/deliveryhub/courier/service/CourierEarningsService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/courier/service/CourierEarningsService.java
@@ -1,0 +1,365 @@
+package com.ubb.deliveryhub.courier.service;
+
+import com.ubb.deliveryhub.courier.CourierEarningsDefaults;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsChartPointDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsEntryDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsQueryDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsSummaryDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsTrendDto;
+import com.ubb.deliveryhub.courier.api.dto.earnings.CourierEarningsWindowDto;
+import com.ubb.deliveryhub.courier.domain.exception.CourierEarningsValidationException;
+import com.ubb.deliveryhub.courier.domain.exception.InvalidCourierEarningsSortException;
+import com.ubb.deliveryhub.delivery.repository.CourierEarningEntryView;
+import com.ubb.deliveryhub.delivery.repository.DeliveryStatusHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CourierEarningsService {
+
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of("recordedAt", "id");
+    private static final int CURRENCY_SCALE = 2;
+
+    private final DeliveryStatusHistoryRepository deliveryStatusHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public CourierEarningsSummaryDto getSummary(Authentication authentication, CourierEarningsQueryDto query) {
+        UUID courierId = principalUserId(authentication);
+        Window customWindow = resolveWindow(query, true);
+        String currency = resolveCurrency(courierId, customWindow.fromInclusive(), customWindow.toExclusive());
+
+        Instant now = Instant.now();
+        Window todayWindow = dayWindow(now);
+        Window weekWindow = weekWindow(now);
+        Window monthWindow = monthWindow(now);
+
+        BigDecimal todayTotal = sumWindow(courierId, currency, todayWindow);
+        BigDecimal weekTotal = sumWindow(courierId, currency, weekWindow);
+        BigDecimal monthTotal = sumWindow(courierId, currency, monthWindow);
+        BigDecimal customRangeTotal = sumWindow(courierId, currency, customWindow);
+
+        Duration span = Duration.between(customWindow.fromInclusive(), customWindow.toExclusive());
+        Window previousWindow = new Window(
+            customWindow.fromInclusive().minus(span),
+            customWindow.fromInclusive()
+        );
+        BigDecimal previousPeriodTotal = sumWindow(courierId, currency, previousWindow);
+        BigDecimal deltaAmount = customRangeTotal.subtract(previousPeriodTotal);
+        BigDecimal deltaPercent = previousPeriodTotal.signum() > 0
+            ? deltaAmount.multiply(BigDecimal.valueOf(100))
+                .divide(previousPeriodTotal, 2, RoundingMode.HALF_UP)
+            : null;
+
+        List<CourierEarningsChartPointDto> chartPoints = toChartPoints(
+            deliveryStatusHistoryRepository.findDeliveredEarningsEntriesInWindow(
+                courierId,
+                currency,
+                customWindow.fromInclusive(),
+                customWindow.toExclusive()
+            ),
+            customWindow
+        );
+
+        return CourierEarningsSummaryDto.builder()
+            .currency(currency)
+            .todayTotal(normalizeAmount(todayTotal))
+            .weekTotal(normalizeAmount(weekTotal))
+            .monthTotal(normalizeAmount(monthTotal))
+            .customRangeTotal(normalizeAmount(customRangeTotal))
+            .trend(CourierEarningsTrendDto.builder()
+                .previousPeriodTotal(normalizeAmount(previousPeriodTotal))
+                .deltaAmount(normalizeAmount(deltaAmount))
+                .deltaPercent(deltaPercent)
+                .build())
+            .window(CourierEarningsWindowDto.builder()
+                .from(customWindow.fromInclusive())
+                .to(customWindow.toExclusive())
+                .timezone(CourierEarningsDefaults.TIMEZONE)
+                .maxRangeDays(CourierEarningsDefaults.MAX_RANGE_DAYS)
+                .build())
+            .chartPoints(chartPoints)
+            .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CourierEarningsEntryDto> getEntries(
+        Authentication authentication,
+        CourierEarningsQueryDto query,
+        Pageable pageable
+    ) {
+        if (!pageable.isPaged()) {
+            throw new CourierEarningsValidationException(
+                "Invalid earnings query",
+                Map.of("page", List.of("Pagination is required"))
+            );
+        }
+
+        assertAllowedSort(pageable.getSort());
+        Pageable effectivePage = applyDefaultSort(pageable);
+        UUID courierId = principalUserId(authentication);
+        Window window = resolveWindow(query, false);
+        String currency = resolveCurrency(courierId, window.fromInclusive(), window.toExclusive());
+        if (window.fromInclusive() == null || window.toExclusive() == null) {
+            return deliveryStatusHistoryRepository.findDeliveredEarningsEntriesForCourier(
+                courierId,
+                currency,
+                effectivePage
+            ).map(this::toEntryDto);
+        }
+        return deliveryStatusHistoryRepository.findDeliveredEarningsEntriesForCourier(
+            courierId,
+            currency,
+            window.fromInclusive(),
+            window.toExclusive(),
+            effectivePage
+        ).map(this::toEntryDto);
+    }
+
+    private CourierEarningsEntryDto toEntryDto(CourierEarningEntryView row) {
+        return CourierEarningsEntryDto.builder()
+            .deliveryId(row.getDeliveryId())
+            .trackingCode(row.getTrackingCode())
+            .amount(normalizeAmount(row.getTotalAmount()))
+            .currency(row.getCurrency())
+            .status(row.getStatus())
+            .earnedAt(row.getRecordedAt())
+            .category("DELIVERY_COMPLETION")
+            .note(row.getNote())
+            .build();
+    }
+
+    private List<CourierEarningsChartPointDto> toChartPoints(List<CourierEarningEntryView> entries, Window window) {
+        Map<LocalDate, BigDecimal> totals = new LinkedHashMap<>();
+        LocalDate dateCursor = toUtcDate(window.fromInclusive());
+        LocalDate toExclusiveDate = toUtcDate(window.toExclusive());
+        while (dateCursor.isBefore(toExclusiveDate)) {
+            totals.put(dateCursor, BigDecimal.ZERO);
+            dateCursor = dateCursor.plusDays(1);
+        }
+
+        for (CourierEarningEntryView row : entries) {
+            LocalDate day = toUtcDate(row.getRecordedAt());
+            if (!totals.containsKey(day)) {
+                continue;
+            }
+            BigDecimal current = totals.get(day);
+            BigDecimal amount = row.getTotalAmount() != null ? row.getTotalAmount() : BigDecimal.ZERO;
+            totals.put(day, current.add(amount));
+        }
+
+        List<CourierEarningsChartPointDto> points = new ArrayList<>();
+        for (Map.Entry<LocalDate, BigDecimal> entry : totals.entrySet()) {
+            Instant bucketStart = entry.getKey().atStartOfDay().toInstant(ZoneOffset.UTC);
+            Instant bucketEnd = entry.getKey().plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+            points.add(CourierEarningsChartPointDto.builder()
+                .bucketStart(bucketStart)
+                .bucketEnd(bucketEnd)
+                .total(normalizeAmount(entry.getValue()))
+                .build());
+        }
+        return points;
+    }
+
+    private String resolveCurrency(UUID courierId, Instant fromInclusive, Instant toExclusive) {
+        List<String> currencies;
+        if (fromInclusive == null || toExclusive == null) {
+            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(courierId);
+        } else {
+            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(
+                courierId,
+                fromInclusive,
+                toExclusive
+            );
+        }
+        if (currencies.isEmpty()) {
+            currencies = deliveryStatusHistoryRepository.findDominantDeliveredCurrenciesForCourier(courierId);
+        }
+        if (currencies.isEmpty()) {
+            return "RON";
+        }
+        String value = currencies.getFirst();
+        return value == null || value.isBlank() ? "RON" : value;
+    }
+
+    private BigDecimal sumWindow(UUID courierId, String currency, Window window) {
+        BigDecimal total = deliveryStatusHistoryRepository.sumDeliveredEarningsByCourierAndCurrencyInWindow(
+            courierId,
+            currency,
+            window.fromInclusive(),
+            window.toExclusive()
+        );
+        return normalizeAmount(total);
+    }
+
+    private Window resolveWindow(CourierEarningsQueryDto query, boolean allowFallback) {
+        String rawFrom = query != null ? query.getFrom() : null;
+        String rawTo = query != null ? query.getTo() : null;
+        boolean hasFrom = rawFrom != null && !rawFrom.isBlank();
+        boolean hasTo = rawTo != null && !rawTo.isBlank();
+
+        if (allowFallback && !hasFrom && !hasTo) {
+            Instant now = Instant.now();
+            return new Window(
+                dayStart(now).minus(Duration.ofDays(13)),
+                dayStart(now).plus(Duration.ofDays(1))
+            );
+        }
+        if (!allowFallback && !hasFrom && !hasTo) {
+            return new Window(null, null);
+        }
+        if (hasFrom != hasTo) {
+            throw new CourierEarningsValidationException(
+                "Invalid earnings query",
+                Map.of("to", List.of("'from' and 'to' must be provided together"))
+            );
+        }
+
+        Instant fromInclusive = parseBoundary(rawFrom, "from", false);
+        Instant toExclusive = parseBoundary(rawTo, "to", true);
+        if (!fromInclusive.isBefore(toExclusive)) {
+            throw new CourierEarningsValidationException(
+                "Invalid earnings query",
+                Map.of("from", List.of("'from' must be before 'to'"))
+            );
+        }
+
+        Duration span = Duration.between(fromInclusive, toExclusive);
+        if (span.compareTo(Duration.ofDays(CourierEarningsDefaults.MAX_RANGE_DAYS)) > 0) {
+            throw new CourierEarningsValidationException(
+                "Invalid earnings query",
+                Map.of(
+                    "to",
+                    List.of("Requested window is too large. Maximum allowed span is %d days."
+                        .formatted(CourierEarningsDefaults.MAX_RANGE_DAYS))
+                )
+            );
+        }
+
+        return new Window(fromInclusive, toExclusive);
+    }
+
+    private static void assertAllowedSort(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return;
+        }
+        for (Sort.Order order : sort) {
+            if (!ALLOWED_SORT_PROPERTIES.contains(order.getProperty())) {
+                throw new InvalidCourierEarningsSortException(order.getProperty(), ALLOWED_SORT_PROPERTIES);
+            }
+        }
+    }
+
+    private static Pageable applyDefaultSort(Pageable pageable) {
+        if (!pageable.getSort().isUnsorted()) {
+            Sort sort = pageable.getSort();
+            boolean hasId = sort.getOrderFor("id") != null;
+            if (hasId) {
+                return pageable;
+            }
+            Sort enrichedSort = sort.and(Sort.by(Sort.Order.desc("id")));
+            return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), enrichedSort);
+        }
+        return PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            Sort.by(
+                Sort.Order.desc(CourierEarningsDefaults.SORT_PROPERTY),
+                Sort.Order.desc("id")
+            )
+        );
+    }
+
+    private static UUID principalUserId(Authentication authentication) {
+        return UUID.fromString(authentication.getName());
+    }
+
+    private Window dayWindow(Instant now) {
+        Instant from = dayStart(now);
+        return new Window(from, from.plus(Duration.ofDays(1)));
+    }
+
+    private Window weekWindow(Instant now) {
+        LocalDate today = toUtcDate(now);
+        LocalDate weekStartDate = today.with(java.time.DayOfWeek.MONDAY);
+        Instant from = weekStartDate.atStartOfDay().toInstant(ZoneOffset.UTC);
+        return new Window(from, from.plus(Duration.ofDays(7)));
+    }
+
+    private Window monthWindow(Instant now) {
+        LocalDate today = toUtcDate(now);
+        LocalDate monthStartDate = today.with(TemporalAdjusters.firstDayOfMonth());
+        Instant from = monthStartDate.atStartOfDay().toInstant(ZoneOffset.UTC);
+        LocalDate nextMonthStartDate = monthStartDate.plusMonths(1);
+        return new Window(from, nextMonthStartDate.atStartOfDay().toInstant(ZoneOffset.UTC));
+    }
+
+    private Instant parseBoundary(String raw, String fieldName, boolean toExclusiveForDateOnly) {
+        try {
+            Instant parsed = Instant.parse(raw);
+            return toExclusiveForDateOnly ? parsed.plusNanos(1) : parsed;
+        } catch (DateTimeParseException ignored) {
+            // fallback
+        }
+        try {
+            Instant parsed = OffsetDateTime.parse(raw).toInstant();
+            return toExclusiveForDateOnly ? parsed.plusNanos(1) : parsed;
+        } catch (DateTimeParseException ignored) {
+            // fallback
+        }
+        try {
+            LocalDate date = LocalDate.parse(raw);
+            if (toExclusiveForDateOnly) {
+                return date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+            }
+            return date.atStartOfDay().toInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException ex) {
+            throw new CourierEarningsValidationException(
+                "Invalid earnings query",
+                Map.of(fieldName, List.of(
+                    "Expected ISO-8601 timestamp or date (example: 2026-05-01T00:00:00Z or 2026-05-01)"
+                ))
+            );
+        }
+    }
+
+    private static BigDecimal normalizeAmount(BigDecimal raw) {
+        if (raw == null) {
+            return BigDecimal.ZERO.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+        }
+        return raw.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private static Instant dayStart(Instant point) {
+        return toUtcDate(point).atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
+
+    private static LocalDate toUtcDate(Instant point) {
+        return point.atOffset(ZoneOffset.UTC).toLocalDate();
+    }
+
+    private record Window(Instant fromInclusive, Instant toExclusive) {
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/CourierEarningEntryView.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/CourierEarningEntryView.java
@@ -1,0 +1,24 @@
+package com.ubb.deliveryhub.delivery.repository;
+
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public interface CourierEarningEntryView {
+
+    UUID getDeliveryId();
+
+    String getTrackingCode();
+
+    BigDecimal getTotalAmount();
+
+    String getCurrency();
+
+    DeliveryStatus getStatus();
+
+    Instant getRecordedAt();
+
+    String getNote();
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusHistoryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.ubb.deliveryhub.delivery.repository;
 
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
+import com.ubb.deliveryhub.delivery.domain.DeliveryStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,12 +22,13 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
         GROUP BY d.currency
         ORDER BY COUNT(h.id) DESC, d.currency ASC
         """)
     List<String> findDominantDeliveredCurrenciesForCourier(
-        @Param("courierId") UUID courierId
+        @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status
     );
 
     @Query("""
@@ -34,7 +36,7 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
           AND h.recordedAt >= :fromInclusive
           AND h.recordedAt < :toExclusive
         GROUP BY d.currency
@@ -42,6 +44,7 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         """)
     List<String> findDominantDeliveredCurrenciesForCourier(
         @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status,
         @Param("fromInclusive") Instant fromInclusive,
         @Param("toExclusive") Instant toExclusive
     );
@@ -51,13 +54,14 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
           AND h.recordedAt >= :fromInclusive
           AND h.recordedAt < :toExclusive
           AND d.currency = :currency
         """)
     BigDecimal sumDeliveredEarningsByCourierAndCurrencyInWindow(
         @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status,
         @Param("currency") String currency,
         @Param("fromInclusive") Instant fromInclusive,
         @Param("toExclusive") Instant toExclusive
@@ -74,13 +78,14 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
           AND h.recordedAt >= :fromInclusive
           AND h.recordedAt < :toExclusive
           AND d.currency = :currency
         """)
     Page<CourierEarningEntryView> findDeliveredEarningsEntriesForCourier(
         @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status,
         @Param("currency") String currency,
         @Param("fromInclusive") Instant fromInclusive,
         @Param("toExclusive") Instant toExclusive,
@@ -98,11 +103,12 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
           AND d.currency = :currency
         """)
     Page<CourierEarningEntryView> findDeliveredEarningsEntriesForCourier(
         @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status,
         @Param("currency") String currency,
         Pageable pageable
     );
@@ -118,7 +124,7 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         FROM DeliveryStatusHistory h
         JOIN h.delivery d
         WHERE d.courier.id = :courierId
-          AND cast(h.status as string) = 'DELIVERED'
+          AND h.status = :status
           AND h.recordedAt >= :fromInclusive
           AND h.recordedAt < :toExclusive
           AND d.currency = :currency
@@ -126,6 +132,7 @@ public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryS
         """)
     List<CourierEarningEntryView> findDeliveredEarningsEntriesInWindow(
         @Param("courierId") UUID courierId,
+        @Param("status") DeliveryStatus status,
         @Param("currency") String currency,
         @Param("fromInclusive") Instant fromInclusive,
         @Param("toExclusive") Instant toExclusive

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusHistoryRepository.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/repository/DeliveryStatusHistoryRepository.java
@@ -1,12 +1,133 @@
 package com.ubb.deliveryhub.delivery.repository;
 
 import com.ubb.deliveryhub.delivery.domain.DeliveryStatusHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 public interface DeliveryStatusHistoryRepository extends JpaRepository<DeliveryStatusHistory, UUID> {
 
     List<DeliveryStatusHistory> findByDelivery_IdOrderByRecordedAtAsc(UUID deliveryId);
+
+    @Query("""
+        SELECT d.currency
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+        GROUP BY d.currency
+        ORDER BY COUNT(h.id) DESC, d.currency ASC
+        """)
+    List<String> findDominantDeliveredCurrenciesForCourier(
+        @Param("courierId") UUID courierId
+    );
+
+    @Query("""
+        SELECT d.currency
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+          AND h.recordedAt >= :fromInclusive
+          AND h.recordedAt < :toExclusive
+        GROUP BY d.currency
+        ORDER BY COUNT(h.id) DESC, d.currency ASC
+        """)
+    List<String> findDominantDeliveredCurrenciesForCourier(
+        @Param("courierId") UUID courierId,
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
+
+    @Query("""
+        SELECT COALESCE(SUM(d.totalAmount), 0)
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+          AND h.recordedAt >= :fromInclusive
+          AND h.recordedAt < :toExclusive
+          AND d.currency = :currency
+        """)
+    BigDecimal sumDeliveredEarningsByCourierAndCurrencyInWindow(
+        @Param("courierId") UUID courierId,
+        @Param("currency") String currency,
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
+
+    @Query("""
+        SELECT d.id AS deliveryId,
+               d.trackingCode AS trackingCode,
+               d.totalAmount AS totalAmount,
+               d.currency AS currency,
+               h.status AS status,
+               h.recordedAt AS recordedAt,
+               h.note AS note
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+          AND h.recordedAt >= :fromInclusive
+          AND h.recordedAt < :toExclusive
+          AND d.currency = :currency
+        """)
+    Page<CourierEarningEntryView> findDeliveredEarningsEntriesForCourier(
+        @Param("courierId") UUID courierId,
+        @Param("currency") String currency,
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive,
+        Pageable pageable
+    );
+
+    @Query("""
+        SELECT d.id AS deliveryId,
+               d.trackingCode AS trackingCode,
+               d.totalAmount AS totalAmount,
+               d.currency AS currency,
+               h.status AS status,
+               h.recordedAt AS recordedAt,
+               h.note AS note
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+          AND d.currency = :currency
+        """)
+    Page<CourierEarningEntryView> findDeliveredEarningsEntriesForCourier(
+        @Param("courierId") UUID courierId,
+        @Param("currency") String currency,
+        Pageable pageable
+    );
+
+    @Query("""
+        SELECT d.id AS deliveryId,
+               d.trackingCode AS trackingCode,
+               d.totalAmount AS totalAmount,
+               d.currency AS currency,
+               h.status AS status,
+               h.recordedAt AS recordedAt,
+               h.note AS note
+        FROM DeliveryStatusHistory h
+        JOIN h.delivery d
+        WHERE d.courier.id = :courierId
+          AND cast(h.status as string) = 'DELIVERED'
+          AND h.recordedAt >= :fromInclusive
+          AND h.recordedAt < :toExclusive
+          AND d.currency = :currency
+        ORDER BY h.recordedAt ASC, d.id ASC
+        """)
+    List<CourierEarningEntryView> findDeliveredEarningsEntriesInWindow(
+        @Param("courierId") UUID courierId,
+        @Param("currency") String currency,
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
 }

--- a/frontend/src/app/core/navigation/app-nav.config.ts
+++ b/frontend/src/app/core/navigation/app-nav.config.ts
@@ -69,7 +69,7 @@ export const APP_NAV_SECTIONS: readonly NavSection[] = [
         linkActiveExact: true,
       },
       {
-        label: 'Earnings',
+        label: 'Earnings & History',
         routerCommands: ['courier', 'earnings'],
         icon: 'pi pi-dollar',
         roles: [UserRole.COURIER],

--- a/frontend/src/app/features/courier/courier.routes.ts
+++ b/frontend/src/app/features/courier/courier.routes.ts
@@ -58,8 +58,8 @@ export const courierRoutes: Routes = [
         (m) => m.CourierEarningsPage,
       ),
     data: {
-      pageTitle: 'Earnings',
-      subtitle: 'Track delivered-job income and period trends',
+      pageTitle: 'Earnings & History',
+      subtitle: 'Track your earnings and delivery history',
     },
   },
   {

--- a/frontend/src/app/features/courier/courier.routes.ts
+++ b/frontend/src/app/features/courier/courier.routes.ts
@@ -1,10 +1,5 @@
 import { Routes } from '@angular/router';
 
-const loadStub = () =>
-  import('@shared/pages/portal-route-stub/portal-route-stub').then(
-    (m) => m.PortalRouteStub,
-  );
-
 export const courierRoutes: Routes = [
   {
     path: '',
@@ -58,8 +53,14 @@ export const courierRoutes: Routes = [
   },
   {
     path: 'earnings',
-    loadComponent: loadStub,
-    data: { pageTitle: 'Earnings' },
+    loadComponent: () =>
+      import('./pages/courier-earnings/courier-earnings').then(
+        (m) => m.CourierEarningsPage,
+      ),
+    data: {
+      pageTitle: 'Earnings',
+      subtitle: 'Track delivered-job income and period trends',
+    },
   },
   {
     path: 'profile',

--- a/frontend/src/app/features/courier/models/courier-earnings.models.ts
+++ b/frontend/src/app/features/courier/models/courier-earnings.models.ts
@@ -8,6 +8,7 @@ export interface CourierEarningsQueryParams {
 export interface CourierEarningsWindowDto {
   from: string;
   to: string;
+  toExclusive?: string;
   timezone: string;
   maxRangeDays: number;
 }

--- a/frontend/src/app/features/courier/models/courier-earnings.models.ts
+++ b/frontend/src/app/features/courier/models/courier-earnings.models.ts
@@ -1,0 +1,60 @@
+import { PageDto } from '@core/services/enum/delivery.types';
+
+export interface CourierEarningsQueryParams {
+  from?: string;
+  to?: string;
+}
+
+export interface CourierEarningsWindowDto {
+  from: string;
+  to: string;
+  timezone: string;
+  maxRangeDays: number;
+}
+
+export interface CourierEarningsTrendDto {
+  previousPeriodTotal: number;
+  deltaAmount: number;
+  deltaPercent: number | null;
+}
+
+export interface CourierEarningsChartPointDto {
+  bucketStart: string;
+  bucketEnd: string;
+  total: number;
+}
+
+export interface CourierEarningsSummaryDto {
+  currency: string;
+  todayTotal: number;
+  weekTotal: number;
+  monthTotal: number;
+  customRangeTotal: number;
+  trend: CourierEarningsTrendDto;
+  window: CourierEarningsWindowDto;
+  chartPoints: CourierEarningsChartPointDto[];
+}
+
+export interface CourierEarningsEntryDto {
+  deliveryId: string;
+  trackingCode: string | null;
+  amount: number;
+  currency: string;
+  status: string;
+  earnedAt: string;
+  category: string | null;
+  note: string | null;
+}
+
+export type CourierEarningsEntriesPage = PageDto<CourierEarningsEntryDto>;
+
+export interface CourierEarningsEntriesQuery extends CourierEarningsQueryParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export interface CourierEarningsUiError {
+  status: number;
+  detail: string | null;
+}

--- a/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.html
+++ b/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.html
@@ -1,0 +1,200 @@
+<div class="flex min-h-0 flex-1 flex-col bg-p-surface-ground">
+  <div class="space-y-4 p-5">
+    @if (loading() && !hasLoadedAtLeastOnce()) {
+      <section class="space-y-3">
+        <p-skeleton width="14rem" height="1.2rem" />
+        <p-skeleton width="100%" height="14rem" />
+      </section>
+    } @else if (hardError(); as loadError) {
+      <section
+        class="rounded-(--p-radius-lg) border border-red-200 bg-red-50 p-5 text-sm text-red-700 shadow-(--p-shadow-xs)"
+      >
+        <p class="font-semibold">Earnings unavailable</p>
+        <p class="mt-1">{{ loadError }}</p>
+        <div class="mt-3">
+          <p-button label="Retry" icon="pi pi-refresh" (onClick)="retry()" />
+        </div>
+      </section>
+    } @else {
+      <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+        >
+          <p class="text-[13px] text-p-text-muted">Today</p>
+          <p class="mt-2 text-[28px] leading-none font-semibold text-emerald-600">
+            {{ todayTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+          </p>
+        </article>
+        <article
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+        >
+          <p class="text-[13px] text-p-text-muted">This week</p>
+          <p class="mt-2 text-[28px] leading-none font-semibold text-p-text-primary">
+            {{ weekTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+          </p>
+        </article>
+        <article
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+        >
+          <p class="text-[13px] text-p-text-muted">This month</p>
+          <p class="mt-2 text-[28px] leading-none font-semibold text-p-text-primary">
+            {{ monthTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+          </p>
+        </article>
+        <article
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+        >
+          <p class="text-[13px] text-p-text-muted">{{ customWindowLabel() }}</p>
+          <p class="mt-2 text-[28px] leading-none font-semibold text-blue-600">
+            {{ customRangeTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+          </p>
+          <p class="mt-2 text-xs text-p-text-muted">{{ trendLabel() }}</p>
+        </article>
+      </section>
+
+      <section
+        class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
+      >
+        <div class="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div class="flex flex-wrap items-end gap-2">
+            <label class="flex min-w-32 flex-col gap-1 text-xs text-p-text-muted">
+              From
+              <input
+                type="date"
+                class="rounded-(--p-radius-md) border border-p-surface-border bg-p-surface-ground px-2 py-1.5 text-sm text-p-text-primary"
+                [value]="fromDate()"
+                [disabled]="loading() || refreshing() || entriesLoading()"
+                (change)="updateFromDate($any($event.target).value)"
+              />
+            </label>
+            <label class="flex min-w-32 flex-col gap-1 text-xs text-p-text-muted">
+              To
+              <input
+                type="date"
+                class="rounded-(--p-radius-md) border border-p-surface-border bg-p-surface-ground px-2 py-1.5 text-sm text-p-text-primary"
+                [value]="toDate()"
+                [disabled]="loading() || refreshing() || entriesLoading()"
+                (change)="updateToDate($any($event.target).value)"
+              />
+            </label>
+            <div class="flex gap-2">
+              <p-button
+                label="Apply"
+                icon="pi pi-filter"
+                size="small"
+                [disabled]="loading() || refreshing() || entriesLoading()"
+                (onClick)="applyFilters()"
+              />
+            </div>
+          </div>
+        </div>
+
+        @if (dateRangeError(); as dateError) {
+          <p class="mt-3 text-xs text-red-600">{{ dateError }}</p>
+        }
+
+        @if (transientError(); as refreshError) {
+          <div class="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+            <span class="font-semibold">Refresh failed.</span>
+            <span class="ml-1">{{ refreshError }}</span>
+            <span class="ml-1">Showing last successful snapshot.</span>
+          </div>
+        }
+
+        <div class="mt-4 rounded-(--p-radius-md) border border-p-surface-border bg-white p-3">
+          @if (chartModel().chartData; as chartData) {
+            <div class="h-[360px]">
+              <p-chart
+                styleClass="block h-full w-full"
+                [style]="{ height: '100%' }"
+                type="line"
+                [data]="chartData"
+                [options]="chartModel().chartOptions"
+              />
+            </div>
+          } @else {
+            <div
+              class="rounded border border-dashed border-p-surface-border bg-p-surface-ground p-4 text-sm text-p-text-muted"
+            >
+              No delivered earnings found in the selected range.
+            </div>
+          }
+        </div>
+      </section>
+
+      <section class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card shadow-(--p-shadow-xs)">
+        <p-table
+          [value]="rows()"
+          [lazy]="true"
+          [paginator]="true"
+          [rows]="pageSize()"
+          [first]="activePage() * pageSize()"
+          [totalRecords]="totalRecords()"
+          [loading]="entriesLoading()"
+          dataKey="deliveryId"
+          responsiveLayout="scroll"
+          size="small"
+          styleClass="delivery-list-table"
+          (onLazyLoad)="onLazyLoad($event)"
+        >
+          <ng-template #header>
+            <tr class="border-b border-p-surface-border bg-p-surface-ground">
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Delivery
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Earned at
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Status
+              </th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold tracking-wider text-p-text-muted uppercase">
+                Amount
+              </th>
+            </tr>
+          </ng-template>
+
+          <ng-template #body let-row>
+            <tr class="text-sm text-p-text-secondary transition-colors hover:bg-p-surface-hover">
+              <td class="w-44 px-4 py-3.5 align-top text-[12px] font-semibold text-blue-600">
+                {{ row.shortCode }}
+              </td>
+              <td class="w-44 px-4 py-3.5 align-top text-[13px] text-p-text-primary">
+                {{ row.earnedAt | date: 'medium' }}
+              </td>
+              <td class="w-32 px-4 py-3.5 align-top">
+                <app-status-tag [status]="row.status" size="sm" />
+              </td>
+              <td class="w-36 px-4 py-3.5 align-top text-[13px] font-semibold text-emerald-600">
+                {{ row.amount | currency: row.currency : 'symbol' : '1.2-2' }}
+              </td>
+            </tr>
+          </ng-template>
+
+          <ng-template #emptymessage>
+            <tr>
+              <td colspan="4">
+                <app-table-empty-state
+                  title="No earnings entries"
+                  message="No delivered jobs were found in this period."
+                  icon="pi pi-wallet"
+                />
+              </td>
+            </tr>
+          </ng-template>
+
+          <ng-template #loadingbody>
+            @for (_row of loadingSkeletonRows; track _row) {
+              <tr>
+                <td><p-skeleton height="1rem" width="6rem" /></td>
+                <td><p-skeleton height="1rem" width="9rem" /></td>
+                <td><p-skeleton height="1rem" width="5rem" /></td>
+                <td><p-skeleton height="1rem" width="6rem" /></td>
+              </tr>
+            }
+          </ng-template>
+        </p-table>
+      </section>
+    }
+  </div>
+</div>

--- a/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.html
+++ b/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.html
@@ -16,39 +16,81 @@
         </div>
       </section>
     } @else {
-      <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <article
-          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
         >
-          <p class="text-[13px] text-p-text-muted">Today</p>
-          <p class="mt-2 text-[28px] leading-none font-semibold text-emerald-600">
-            {{ todayTotal() | currency: currency() : 'symbol' : '1.2-2' }}
-          </p>
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[12px] text-p-text-muted">Today's Earnings</p>
+              <p class="mt-2 text-[30px] leading-none font-semibold text-emerald-600">
+                {{ todayTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+              </p>
+            </div>
+            <span
+              class="inline-flex h-10 w-10 items-center justify-center rounded-(--p-radius-sm) bg-emerald-50 text-emerald-600"
+            >
+              <i class="pi pi-dollar text-base" aria-hidden="true"></i>
+            </span>
+          </div>
         </article>
+
         <article
-          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
         >
-          <p class="text-[13px] text-p-text-muted">This week</p>
-          <p class="mt-2 text-[28px] leading-none font-semibold text-p-text-primary">
-            {{ weekTotal() | currency: currency() : 'symbol' : '1.2-2' }}
-          </p>
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[12px] text-p-text-muted">This Week</p>
+              <p class="mt-2 text-[30px] leading-none font-semibold text-slate-800">
+                {{ weekTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+              </p>
+            </div>
+            <span
+              class="inline-flex h-10 w-10 items-center justify-center rounded-(--p-radius-sm) bg-blue-50 text-blue-600"
+            >
+              <i class="pi pi-chart-line text-base" aria-hidden="true"></i>
+            </span>
+          </div>
         </article>
+
         <article
-          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
         >
-          <p class="text-[13px] text-p-text-muted">This month</p>
-          <p class="mt-2 text-[28px] leading-none font-semibold text-p-text-primary">
-            {{ monthTotal() | currency: currency() : 'symbol' : '1.2-2' }}
-          </p>
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[12px] text-p-text-muted">This Month</p>
+              <p class="mt-2 text-[30px] leading-none font-semibold text-slate-800">
+                {{ monthTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+              </p>
+            </div>
+            <span
+              class="inline-flex h-10 w-10 items-center justify-center rounded-(--p-radius-sm) bg-cyan-50 text-cyan-700"
+            >
+              <i class="pi pi-calendar text-base" aria-hidden="true"></i>
+            </span>
+          </div>
         </article>
+
         <article
-          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card px-5 py-4 shadow-(--p-shadow-xs)"
+          class="rounded-(--p-radius-lg) border border-p-surface-border bg-p-surface-card p-4 shadow-(--p-shadow-xs)"
         >
-          <p class="text-[13px] text-p-text-muted">{{ customWindowLabel() }}</p>
-          <p class="mt-2 text-[28px] leading-none font-semibold text-blue-600">
-            {{ customRangeTotal() | currency: currency() : 'symbol' : '1.2-2' }}
-          </p>
-          <p class="mt-2 text-xs text-p-text-muted">{{ trendLabel() }}</p>
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[12px] text-p-text-muted">Total Earnings</p>
+              <p class="mt-2 text-[30px] leading-none font-semibold text-slate-800">
+                {{ customRangeTotal() | currency: currency() : 'symbol' : '1.2-2' }}
+              </p>
+            </div>
+            <span
+              class="inline-flex h-10 w-10 items-center justify-center rounded-(--p-radius-sm) bg-amber-50 text-amber-700"
+            >
+              <i class="pi pi-wallet text-base" aria-hidden="true"></i>
+            </span>
+          </div>
+          <p class="mt-2 text-xs text-p-text-muted">{{ customWindowLabel() }}</p>
+          @if (trendLabel(); as trend) {
+            <p class="mt-1 text-xs text-p-text-muted">{{ trend }}</p>
+          }
         </article>
       </section>
 
@@ -102,6 +144,7 @@
         }
 
         <div class="mt-4 rounded-(--p-radius-md) border border-p-surface-border bg-white p-3">
+          <p class="mb-3 text-sm font-semibold text-p-text-primary">Earnings Trend</p>
           @if (chartModel().chartData; as chartData) {
             <div class="h-[360px]">
               <p-chart

--- a/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.ts
+++ b/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.ts
@@ -1,0 +1,335 @@
+import { CurrencyPipe, DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { StatusTagComponent, TableEmptyStateComponent } from '@shared/ui/public-api';
+import { Button } from 'primeng/button';
+import { UIChart } from 'primeng/chart';
+import { Skeleton } from 'primeng/skeleton';
+import { TableLazyLoadEvent, TableModule } from 'primeng/table';
+import { catchError, finalize, forkJoin, of } from 'rxjs';
+import {
+  CourierEarningsEntriesPage,
+  CourierEarningsEntryDto,
+  CourierEarningsSummaryDto,
+} from '../../models/courier-earnings.models';
+import { CourierEarningsService } from '../../services/courier-earnings.service';
+import { mapEarningsToChart } from '../../utils/courier-earnings-chart.mapper';
+
+type LoadMode = 'initial' | 'filter' | 'retry';
+
+interface EarningsEntryRow {
+  deliveryId: string;
+  shortCode: string;
+  earnedAt: string;
+  amount: number;
+  currency: string;
+  status: string;
+}
+
+@Component({
+  selector: 'app-courier-earnings-page',
+  imports: [
+    CurrencyPipe,
+    DatePipe,
+    Button,
+    Skeleton,
+    TableModule,
+    UIChart,
+    StatusTagComponent,
+    TableEmptyStateComponent,
+  ],
+  templateUrl: './courier-earnings.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CourierEarningsPage {
+  private static readonly DEFAULT_PAGE_SIZE = 10;
+
+  private readonly courierEarningsService = inject(CourierEarningsService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly loading = signal(false);
+  protected readonly refreshing = signal(false);
+  protected readonly entriesLoading = signal(false);
+  protected readonly hasLoadedAtLeastOnce = signal(false);
+  protected readonly hardError = signal<string | null>(null);
+  protected readonly transientError = signal<string | null>(null);
+  protected readonly dateRangeError = signal<string | null>(null);
+
+  protected readonly fromDate = signal(this.toInputDate(-13));
+  protected readonly toDate = signal(this.toInputDate(0));
+  protected readonly maxRangeDays = signal(180);
+
+  protected readonly summary = signal<CourierEarningsSummaryDto | null>(null);
+  protected readonly rows = signal<EarningsEntryRow[]>([]);
+  protected readonly totalRecords = signal(0);
+  protected readonly activePage = signal(0);
+  protected readonly pageSize = signal(CourierEarningsPage.DEFAULT_PAGE_SIZE);
+  protected readonly loadingSkeletonRows = [0, 1, 2, 3];
+
+  protected readonly chartModel = computed(() => mapEarningsToChart(this.summary()));
+  protected readonly currency = computed(() => this.summary()?.currency ?? 'RON');
+  protected readonly todayTotal = computed(() => this.summary()?.todayTotal ?? 0);
+  protected readonly weekTotal = computed(() => this.summary()?.weekTotal ?? 0);
+  protected readonly monthTotal = computed(() => this.summary()?.monthTotal ?? 0);
+  protected readonly customRangeTotal = computed(
+    () => this.summary()?.customRangeTotal ?? 0,
+  );
+  protected readonly customWindowLabel = computed(() => {
+    const summary = this.summary();
+    if (!summary) {
+      return 'Selected range';
+    }
+    const from = this.formatDate(summary.window.from);
+    const to = this.formatDate(summary.window.to);
+    return `${from} -> ${to}`;
+  });
+  protected readonly trendLabel = computed(() => {
+    const trend = this.summary()?.trend;
+    if (!trend || trend.deltaPercent === null) {
+      return 'No previous period baseline available yet';
+    }
+    const direction = trend.deltaPercent >= 0 ? '+' : '';
+    return `${direction}${trend.deltaPercent.toFixed(2)}% vs previous period`;
+  });
+
+  constructor() {
+    this.loadSnapshot('initial');
+  }
+
+  protected applyFilters(): void {
+    if (!this.validateFilters()) {
+      return;
+    }
+    this.activePage.set(0);
+    this.loadSnapshot('filter');
+  }
+
+  protected retry(): void {
+    this.loadSnapshot('retry');
+  }
+
+  protected updateFromDate(value: string): void {
+    this.fromDate.set(value);
+    this.dateRangeError.set(null);
+  }
+
+  protected updateToDate(value: string): void {
+    this.toDate.set(value);
+    this.dateRangeError.set(null);
+  }
+
+  protected onLazyLoad(event: TableLazyLoadEvent): void {
+    if (!this.hasLoadedAtLeastOnce()) {
+      return;
+    }
+
+    const rows =
+      typeof event.rows === 'number' && event.rows > 0
+        ? event.rows
+        : this.pageSize();
+    const first =
+      typeof event.first === 'number' && event.first >= 0
+        ? event.first
+        : this.activePage() * this.pageSize();
+    const page = Math.floor(first / rows);
+
+    if (rows === this.pageSize() && page === this.activePage()) {
+      return;
+    }
+
+    this.pageSize.set(rows);
+    this.activePage.set(page);
+    this.loadEntriesPage();
+  }
+
+  private loadSnapshot(mode: LoadMode): void {
+    if (this.loading() || this.refreshing()) {
+      return;
+    }
+    const hasSnapshot = this.summary() !== null;
+    this.hardError.set(null);
+    this.transientError.set(null);
+
+    if (hasSnapshot || mode !== 'initial') {
+      this.refreshing.set(true);
+    } else {
+      this.loading.set(true);
+    }
+
+    const query = this.buildRangeQuery();
+    const pageQuery = {
+      ...query,
+      page: this.activePage(),
+      size: this.pageSize(),
+      sort: 'recordedAt,desc',
+    };
+
+    forkJoin({
+      summary: this.courierEarningsService.getSummary(query),
+      entries: this.courierEarningsService.getEntries(pageQuery),
+    })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading.set(false);
+          this.refreshing.set(false);
+        }),
+      )
+      .subscribe({
+        next: ({ summary, entries }) => {
+          this.summary.set(summary);
+          this.maxRangeDays.set(summary.window.maxRangeDays);
+          this.applyEntries(entries);
+          this.hasLoadedAtLeastOnce.set(true);
+        },
+        error: (error: unknown) => {
+          const uiError = this.courierEarningsService.toUiError(error);
+          const detail =
+            uiError.detail ??
+            'Earnings data could not be loaded. Please retry in a few moments.';
+          if (hasSnapshot) {
+            this.transientError.set(detail);
+            return;
+          }
+          this.hardError.set(detail);
+          this.hasLoadedAtLeastOnce.set(true);
+        },
+      });
+  }
+
+  private loadEntriesPage(): void {
+    if (this.entriesLoading() || this.loading() || this.refreshing()) {
+      return;
+    }
+    this.entriesLoading.set(true);
+    this.transientError.set(null);
+
+    this.courierEarningsService
+      .getEntries({
+        ...this.buildRangeQuery(),
+        page: this.activePage(),
+        size: this.pageSize(),
+        sort: 'recordedAt,desc',
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        catchError((error) => {
+          const uiError = this.courierEarningsService.toUiError(error);
+          this.transientError.set(
+            uiError.detail ??
+              'Entries could not be refreshed. Showing the last successful page.',
+          );
+          return of<CourierEarningsEntriesPage>({
+            content: this.rows().map((row) => ({
+              deliveryId: row.deliveryId,
+              trackingCode: row.shortCode,
+              amount: row.amount,
+              currency: row.currency,
+              status: row.status,
+              earnedAt: row.earnedAt,
+              category: null,
+              note: null,
+            })),
+            totalElements: this.totalRecords(),
+            totalPages: 0,
+            size: this.pageSize(),
+            number: this.activePage(),
+          });
+        }),
+        finalize(() => this.entriesLoading.set(false)),
+      )
+      .subscribe((page) => this.applyEntries(page));
+  }
+
+  private applyEntries(page: CourierEarningsEntriesPage): void {
+    const rows = Array.isArray(page.content) ? page.content : [];
+    this.rows.set(rows.map((entry) => this.toRow(entry)));
+    this.totalRecords.set(this.toNonNegative(page.totalElements));
+  }
+
+  private toRow(entry: CourierEarningsEntryDto): EarningsEntryRow {
+    const fallbackCode = entry.deliveryId.trim().replaceAll('-', '').slice(0, 8).toUpperCase();
+    return {
+      deliveryId: entry.deliveryId,
+      shortCode: entry.trackingCode?.trim() || `DLV-${fallbackCode || '00000000'}`,
+      earnedAt: entry.earnedAt,
+      amount: this.toNonNegative(entry.amount),
+      currency: entry.currency?.trim().toUpperCase() || 'RON',
+      status: entry.status || 'DELIVERED',
+    };
+  }
+
+  private buildRangeQuery(): { from: string; to: string } {
+    return {
+      from: this.fromDate().trim(),
+      to: this.toDate().trim(),
+    };
+  }
+
+  private validateFilters(): boolean {
+    const from = this.fromDate().trim();
+    const to = this.toDate().trim();
+    if (!from || !to) {
+      this.dateRangeError.set('Both "From" and "To" are required.');
+      return false;
+    }
+
+    const fromEpoch = Date.parse(`${from}T00:00:00Z`);
+    const toEpoch = Date.parse(`${to}T00:00:00Z`);
+    if (Number.isNaN(fromEpoch) || Number.isNaN(toEpoch)) {
+      this.dateRangeError.set('Please enter valid dates before applying filters.');
+      return false;
+    }
+    if (fromEpoch > toEpoch) {
+      this.dateRangeError.set('"From" date cannot be after "To" date.');
+      return false;
+    }
+
+    const diffDays = Math.floor((toEpoch - fromEpoch) / (24 * 60 * 60 * 1000)) + 1;
+    if (diffDays > this.maxRangeDays()) {
+      this.dateRangeError.set(
+        `Selected range exceeds the maximum allowed window (${this.maxRangeDays()} days).`,
+      );
+      return false;
+    }
+
+    this.dateRangeError.set(null);
+    return true;
+  }
+
+  private formatDate(value: string): string {
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return '-';
+    }
+    return new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'medium',
+      timeZone: 'UTC',
+    }).format(new Date(parsed));
+  }
+
+  private toNonNegative(value: unknown): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.max(0, value);
+  }
+
+  private toInputDate(dayOffset: number): string {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + dayOffset);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.ts
+++ b/frontend/src/app/features/courier/pages/courier-earnings/courier-earnings.ts
@@ -93,7 +93,7 @@ export class CourierEarningsPage {
   protected readonly trendLabel = computed(() => {
     const trend = this.summary()?.trend;
     if (!trend || trend.deltaPercent === null) {
-      return 'No previous period baseline available yet';
+      return null;
     }
     const direction = trend.deltaPercent >= 0 ? '+' : '';
     return `${direction}${trend.deltaPercent.toFixed(2)}% vs previous period`;

--- a/frontend/src/app/features/courier/services/courier-earnings.service.ts
+++ b/frontend/src/app/features/courier/services/courier-earnings.service.ts
@@ -91,6 +91,7 @@ export class CourierEarningsService extends BaseService {
       window: {
         from: this.toIsoDate(window['from']) ?? new Date().toISOString(),
         to: this.toIsoDate(window['to']) ?? new Date().toISOString(),
+        toExclusive: this.toIsoDate(window['toExclusive']) ?? undefined,
         timezone: this.toText(window['timezone']) ?? 'UTC',
         maxRangeDays: this.toPositiveInt(window['maxRangeDays'], 180),
       },

--- a/frontend/src/app/features/courier/services/courier-earnings.service.ts
+++ b/frontend/src/app/features/courier/services/courier-earnings.service.ts
@@ -1,0 +1,203 @@
+import { HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BaseService } from '@core/services/base.service';
+import { map, Observable } from 'rxjs';
+import {
+  CourierEarningsEntriesPage,
+  CourierEarningsEntriesQuery,
+  CourierEarningsEntryDto,
+  CourierEarningsQueryParams,
+  CourierEarningsSummaryDto,
+  CourierEarningsUiError,
+} from '../models/courier-earnings.models';
+
+type UnknownRecord = Record<string, unknown>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CourierEarningsService extends BaseService {
+  getSummary(params: CourierEarningsQueryParams): Observable<CourierEarningsSummaryDto> {
+    return this.httpClient
+      .get<unknown>(`${this.baseUrl}/couriers/me/earnings/summary`, {
+        params: this.toRangeParams(params),
+      })
+      .pipe(map((response) => this.normalizeSummary(response)));
+  }
+
+  getEntries(params: CourierEarningsEntriesQuery): Observable<CourierEarningsEntriesPage> {
+    return this.httpClient
+      .get<unknown>(`${this.baseUrl}/couriers/me/earnings/entries`, {
+        params: this.toEntriesParams(params),
+      })
+      .pipe(map((response) => this.normalizeEntriesPage(response)));
+  }
+
+  toUiError(error: unknown): CourierEarningsUiError {
+    if (!(error instanceof HttpErrorResponse)) {
+      return { status: 0, detail: null };
+    }
+    return {
+      status: error.status,
+      detail: this.extractErrorDetail(error),
+    };
+  }
+
+  private toEntriesParams(params: CourierEarningsEntriesQuery): HttpParams {
+    let query = this.toRangeParams(params);
+    if (params.page !== undefined) {
+      query = query.set('page', params.page);
+    }
+    if (params.size !== undefined) {
+      query = query.set('size', params.size);
+    }
+    if (params.sort && params.sort.trim().length > 0) {
+      query = query.set('sort', params.sort.trim());
+    }
+    return query;
+  }
+
+  private toRangeParams(params: CourierEarningsQueryParams): HttpParams {
+    let query = new HttpParams();
+    const from = this.toText(params.from);
+    const to = this.toText(params.to);
+    if (from) {
+      query = query.set('from', from);
+    }
+    if (to) {
+      query = query.set('to', to);
+    }
+    return query;
+  }
+
+  private normalizeSummary(response: unknown): CourierEarningsSummaryDto {
+    const candidate = this.asRecord(response);
+    const trend = this.asRecord(candidate['trend']);
+    const window = this.asRecord(candidate['window']);
+    const chartPoints = this.toArray(candidate['chartPoints']).map((entry) =>
+      this.normalizeChartPoint(entry),
+    );
+    return {
+      currency: this.toCurrency(candidate['currency']),
+      todayTotal: this.toFiniteNumber(candidate['todayTotal']),
+      weekTotal: this.toFiniteNumber(candidate['weekTotal']),
+      monthTotal: this.toFiniteNumber(candidate['monthTotal']),
+      customRangeTotal: this.toFiniteNumber(candidate['customRangeTotal']),
+      trend: {
+        previousPeriodTotal: this.toFiniteNumber(trend['previousPeriodTotal']),
+        deltaAmount: this.toFiniteNumber(trend['deltaAmount']),
+        deltaPercent: this.toNullableFiniteNumber(trend['deltaPercent']),
+      },
+      window: {
+        from: this.toIsoDate(window['from']) ?? new Date().toISOString(),
+        to: this.toIsoDate(window['to']) ?? new Date().toISOString(),
+        timezone: this.toText(window['timezone']) ?? 'UTC',
+        maxRangeDays: this.toPositiveInt(window['maxRangeDays'], 180),
+      },
+      chartPoints,
+    };
+  }
+
+  private normalizeEntriesPage(response: unknown): CourierEarningsEntriesPage {
+    const candidate = this.asRecord(response);
+    const content = this.toArray(candidate['content']).map((entry) =>
+      this.normalizeEntry(entry),
+    );
+    return {
+      content,
+      totalElements: this.toNonNegativeInt(candidate['totalElements']),
+      totalPages: this.toNonNegativeInt(candidate['totalPages']),
+      size: this.toNonNegativeInt(candidate['size']),
+      number: this.toNonNegativeInt(candidate['number']),
+    };
+  }
+
+  private normalizeChartPoint(value: unknown) {
+    const candidate = this.asRecord(value);
+    return {
+      bucketStart: this.toIsoDate(candidate['bucketStart']) ?? new Date().toISOString(),
+      bucketEnd: this.toIsoDate(candidate['bucketEnd']) ?? new Date().toISOString(),
+      total: this.toFiniteNumber(candidate['total']),
+    };
+  }
+
+  private normalizeEntry(value: unknown): CourierEarningsEntryDto {
+    const candidate = this.asRecord(value);
+    return {
+      deliveryId: this.toText(candidate['deliveryId']) ?? '',
+      trackingCode: this.toText(candidate['trackingCode']),
+      amount: this.toFiniteNumber(candidate['amount']),
+      currency: this.toCurrency(candidate['currency']),
+      status: this.toText(candidate['status']) ?? 'DELIVERED',
+      earnedAt: this.toIsoDate(candidate['earnedAt']) ?? new Date().toISOString(),
+      category: this.toText(candidate['category']),
+      note: this.toText(candidate['note']),
+    };
+  }
+
+  private extractErrorDetail(error: HttpErrorResponse): string | null {
+    const body = this.asRecord(error.error);
+    return (
+      this.toText(body['detail']) ??
+      this.toText(body['message']) ??
+      this.toText(body['title']) ??
+      this.toText(body['error'])
+    );
+  }
+
+  private asRecord(value: unknown): UnknownRecord {
+    return value && typeof value === 'object' ? (value as UnknownRecord) : {};
+  }
+
+  private toArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+  }
+
+  private toFiniteNumber(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+  }
+
+  private toNullableFiniteNumber(value: unknown): number | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    return this.toFiniteNumber(value);
+  }
+
+  private toNonNegativeInt(value: unknown): number {
+    const parsed = Math.floor(this.toFiniteNumber(value));
+    return parsed >= 0 ? parsed : 0;
+  }
+
+  private toPositiveInt(value: unknown, fallback: number): number {
+    const parsed = this.toNonNegativeInt(value);
+    return parsed > 0 ? parsed : fallback;
+  }
+
+  private toCurrency(value: unknown): string {
+    const normalized = this.toText(value);
+    return normalized ? normalized.toUpperCase() : 'RON';
+  }
+
+  private toIsoDate(value: unknown): string | null {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      return null;
+    }
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return null;
+    }
+    return new Date(parsed).toISOString();
+  }
+
+  private toText(value: unknown): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  }
+}

--- a/frontend/src/app/features/courier/utils/courier-earnings-chart.mapper.ts
+++ b/frontend/src/app/features/courier/utils/courier-earnings-chart.mapper.ts
@@ -1,0 +1,79 @@
+import { CourierEarningsSummaryDto } from '../models/courier-earnings.models';
+
+export interface CourierEarningsChartMapping {
+  chartData: Record<string, unknown> | null;
+  chartOptions: Record<string, unknown>;
+}
+
+export function mapEarningsToChart(
+  summary: CourierEarningsSummaryDto | null,
+): CourierEarningsChartMapping {
+  if (!summary || summary.chartPoints.length === 0) {
+    return {
+      chartData: null,
+      chartOptions: buildChartOptions(summary?.currency ?? 'RON'),
+    };
+  }
+
+  const chartData = {
+    labels: summary.chartPoints.map((point) => formatShortDate(point.bucketStart)),
+    datasets: [
+      {
+        label: `Earnings (${summary.currency})`,
+        data: summary.chartPoints.map((point) => point.total),
+        borderColor: '#10b981',
+        backgroundColor: 'rgba(16, 185, 129, 0.2)',
+        fill: true,
+        tension: 0.3,
+      },
+    ],
+  };
+
+  return {
+    chartData,
+    chartOptions: buildChartOptions(summary.currency),
+  };
+}
+
+function buildChartOptions(currency: string): Record<string, unknown> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: 'bottom' },
+      tooltip: {
+        callbacks: {
+          label: (ctx: { parsed?: { y?: number } }) => {
+            const value = typeof ctx?.parsed?.y === 'number' ? ctx.parsed.y : 0;
+            return new Intl.NumberFormat('en-US', {
+              style: 'currency',
+              currency,
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            }).format(value);
+          },
+        },
+      },
+    },
+    scales: {
+      x: { ticks: { color: '#64748b' } },
+      y: {
+        beginAtZero: true,
+        ticks: {
+          color: '#64748b',
+        },
+      },
+    },
+  };
+}
+
+function formatShortDate(value: string): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return '-';
+  }
+  return new Intl.DateTimeFormat('en-GB', {
+    month: 'short',
+    day: '2-digit',
+  }).format(new Date(parsed));
+}

--- a/frontend/src/app/features/courier/utils/courier-earnings-chart.mapper.ts
+++ b/frontend/src/app/features/courier/utils/courier-earnings-chart.mapper.ts
@@ -75,5 +75,6 @@ function formatShortDate(value: string): string {
   return new Intl.DateTimeFormat('en-GB', {
     month: 'short',
     day: '2-digit',
+    timeZone: 'UTC',
   }).format(new Date(parsed));
 }


### PR DESCRIPTION
This pull request introduces a new set of APIs and supporting code to provide couriers with visibility into their earnings. The implementation includes REST endpoints for retrieving earnings summaries and entry lists, DTOs for API payloads, validation and exception handling, and documentation updates. The earnings data is derived from delivery history rather than a dedicated ledger, and includes support for filtering, pagination, and error reporting.

**Courier Earnings API Implementation**

* Added new courier earnings endpoints under `/api/couriers/me/earnings` for retrieving summary and entries, including query support for date ranges and pagination. (`CourierEarningsController.java`, `CourierEarningsDefaults.java`, `CourierEarningsQueryDto.java`)
* Defined API response DTOs for summary, entry, chart point, trend, and window metadata. (`CourierEarningsSummaryDto.java`, `CourierEarningsEntryDto.java`, `CourierEarningsChartPointDto.java`, `CourierEarningsTrendDto.java`, `CourierEarningsWindowDto.java`)

**Validation and Error Handling**

* Implemented custom exception classes for validation and sort errors, and a controller advice to return structured error responses for these cases. (`CourierEarningsValidationException.java`, `InvalidCourierEarningsSortException.java`, `CourierEarningsExceptionHandler.java`)

**Documentation**

* Updated `backend/README.md` to document the new courier earnings API endpoints, query semantics, and payload structure.