### PR TITLE
RabbitMQ: notification consumer + DLQ (#69)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -199,6 +199,30 @@ Runtime mode is controlled by properties:
 - `notifications.async.enabled=true`: listener publishes event payload to RabbitMQ (`notifications.async.exchange` + `notifications.async.routing-key`).
 - `notifications.async.fallback-to-sync=true`: if async publish fails, listener falls back to sync persistence.
 
+## Async notification consumer with DLQ (`#69`)
+
+`NotificationRequested` is consumed with manual-ack semantics and explicit transient/permanent classification:
+
+- validation failures (unsupported `eventVersion`, malformed payload, invalid recipients, oversized metadata) are treated as permanent and routed directly to DLQ
+- transient failures are retried using `notifications.async.retry-backoff-millis` until `notifications.async.max-retries` is exhausted
+- exhausted messages are published to DLQ with diagnostic headers:
+  - `x-failure-reason`
+  - `x-exception-class`
+  - `x-attempt-count`
+  - `x-original-exchange`
+  - `x-original-routing-key`
+  - `x-correlation-id`
+
+Topology defaults:
+
+- exchange: `notification.events`
+- routing key: `notification.requested`
+- queue: `notification.consume.q`
+- retry queue: `notification.consume.retry.q`
+- DLX/DLQ: `notification.consume.dlx` / `notification.consume.dlq`
+
+Operational replay guidance is documented in `docs/notification-dlq-runbook.md`.
+
 ## Async assignment consumer (`#68`)
 
 Delivery creation now publishes a versioned `DeliveryCreated` event after transaction commit (feature-flagged), and RabbitMQ consumer-based assignment can process the event asynchronously with idempotency + retry + DLQ flow.

--- a/backend/README.md
+++ b/backend/README.md
@@ -221,6 +221,17 @@ Topology defaults:
 - retry queue: `notification.consume.retry.q`
 - DLX/DLQ: `notification.consume.dlx` / `notification.consume.dlq`
 
+Migration note (breaking default rename):
+
+- previous defaults were `deliveryhub.notifications` + `requested`
+- environments still using legacy topology must explicitly override:
+  - `notifications.async.exchange=deliveryhub.notifications`
+  - `notifications.async.routing-key=requested`
+  - `notifications.async.retry-routing-key=requested.retry`
+  - `notifications.async.dlx=deliveryhub.notifications.dlx`
+  - `notifications.async.dlq-routing-key=requested.dlq`
+- if any legacy exchange/queue bindings are provisioned outside app startup, update or keep overrides before deploying this branch
+
 Operational replay guidance is documented in `docs/notification-dlq-runbook.md`.
 
 ## Async assignment consumer (`#68`)

--- a/backend/docs/notification-dlq-runbook.md
+++ b/backend/docs/notification-dlq-runbook.md
@@ -2,6 +2,20 @@
 
 This runbook covers safe inspection and replay for `NotificationRequested` poison or exhausted messages.
 
+## Topology migration note
+
+This branch uses new notification topology defaults:
+
+- exchange: `notification.events`
+- routing key: `notification.requested`
+
+Legacy deployments may still publish to:
+
+- exchange: `deliveryhub.notifications`
+- routing key: `requested`
+
+If legacy naming is still active in your environment, set explicit property overrides before deploy/replay to avoid silent interoperability breaks.
+
 ## 1) Inspect DLQ messages safely
 
 1. Pause or scale down the notification consumer if you need a stable snapshot.

--- a/backend/docs/notification-dlq-runbook.md
+++ b/backend/docs/notification-dlq-runbook.md
@@ -1,0 +1,54 @@
+# Notification DLQ Runbook
+
+This runbook covers safe inspection and replay for `NotificationRequested` poison or exhausted messages.
+
+## 1) Inspect DLQ messages safely
+
+1. Pause or scale down the notification consumer if you need a stable snapshot.
+2. Open RabbitMQ management UI and inspect queue `notification.consume.dlq`.
+3. For each message, record:
+   - `eventId` from payload
+   - `x-failure-reason`
+   - `x-exception-class`
+   - `x-attempt-count`
+   - `x-correlation-id`
+4. Group failures by reason before replaying. Do not replay blindly.
+
+## 2) Decide replay eligibility
+
+Replay only after remediation is confirmed:
+
+- code fix deployed for validation/classification bug, or
+- configuration corrected (routing/template/environment), or
+- transient dependency issue is resolved.
+
+Never replay while the root cause is still present; messages will cycle back into DLQ.
+
+## 3) Replay process
+
+Recommended approach:
+
+1. Keep idempotency enabled (`dedupe_key = eventId:targetUserId`).
+2. Replay in bounded batches (for example 50-200 messages).
+3. Republish payload to:
+   - exchange: `notification.events`
+   - routing key: `notification.requested`
+4. Preserve or reattach `x-correlation-id` when possible for traceability.
+
+Manual replay can be done from RabbitMQ UI ("Get messages" + republish) or by an operational script using the same exchange/routing key.
+
+## 4) Safety checklist (mandatory)
+
+- [ ] Root cause fixed before replay
+- [ ] Consumer enabled and healthy
+- [ ] Replay batch size bounded
+- [ ] `notification.async.consume{outcome="duplicate"}` monitored during replay
+- [ ] `notification.async.consume{outcome="dlq"}` not increasing unexpectedly
+- [ ] Notification rows verified in DB after each batch
+
+## 5) Post-replay verification
+
+1. Confirm DLQ depth decreases as expected.
+2. Verify spot-sampled users received one effective notification per `(eventId,targetUserId)`.
+3. Check logs by `eventId`/`correlationId` for `outcome=success|duplicate`.
+4. Document replay window, batch size, and outcomes in incident notes.

--- a/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/delivery/service/DeliveryService.java
@@ -427,7 +427,9 @@ public class DeliveryService {
         }
         notificationEventPublisher.publish(
             new NotificationRequested(
+                1,
                 UUID.randomUUID(),
+                resolveCorrelationId(),
                 NotificationEventType.ASSIGNMENT_ACCEPTED,
                 delivery.getId(),
                 actorId,
@@ -448,7 +450,9 @@ public class DeliveryService {
         }
         notificationEventPublisher.publish(
             new NotificationRequested(
+                1,
                 UUID.randomUUID(),
+                resolveCorrelationId(),
                 NotificationEventType.STATUS_UPDATED,
                 delivery.getId(),
                 actorId,

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationAsyncMetrics.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationAsyncMetrics.java
@@ -1,0 +1,25 @@
+package com.ubb.deliveryhub.notification.application;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class NotificationAsyncMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    public NotificationAsyncMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void recordConsume(String outcome, Duration duration) {
+        meterRegistry.counter("notification.async.consume", "outcome", outcome).increment();
+        meterRegistry.timer("notification.async.process.duration", "outcome", outcome).record(duration);
+    }
+
+    public void recordDlqPublish() {
+        meterRegistry.counter("notification.async.dlq.publish").increment();
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationAsyncProcessor.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationAsyncProcessor.java
@@ -1,0 +1,56 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+public class NotificationAsyncProcessor {
+
+    private final NotificationTemplateService templateService;
+    private final NotificationPersistenceService persistenceService;
+
+    public NotificationAsyncProcessor(
+        NotificationTemplateService templateService,
+        NotificationPersistenceService persistenceService
+    ) {
+        this.templateService = templateService;
+        this.persistenceService = persistenceService;
+    }
+
+    @Transactional
+    public Outcome process(NotificationRequested event) {
+        int persistedCount = 0;
+        int duplicateCount = 0;
+        for (UUID recipientUserId : event.targetUserIds()) {
+            NotificationDraft draft = templateService.render(event, recipientUserId);
+            String dedupeKey = dedupeKey(event, recipientUserId);
+            boolean persisted = persistenceService.persist(event, recipientUserId, draft, dedupeKey);
+            if (persisted) {
+                persistedCount++;
+            } else {
+                duplicateCount++;
+            }
+        }
+        if (persistedCount == 0 && duplicateCount > 0) {
+            return Outcome.DUPLICATE;
+        }
+        return Outcome.SUCCESS;
+    }
+
+    private static String dedupeKey(NotificationRequested event, UUID recipientUserId) {
+        String eventToken = Objects.toString(event.eventId(), "NA");
+        return ("%s:%s")
+            .formatted(eventToken, recipientUserId)
+            .toLowerCase(Locale.ROOT);
+    }
+
+    public enum Outcome {
+        SUCCESS,
+        DUPLICATE
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationMessageFailureClassifier.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationMessageFailureClassifier.java
@@ -1,0 +1,44 @@
+package com.ubb.deliveryhub.notification.application;
+
+import com.ubb.deliveryhub.notification.application.exception.PermanentNotificationMessageException;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLTransientException;
+
+@Component
+public class NotificationMessageFailureClassifier {
+
+    public FailureType classify(Throwable throwable) {
+        if (throwable instanceof PermanentNotificationMessageException
+            || throwable instanceof IllegalArgumentException) {
+            return FailureType.PERMANENT;
+        }
+        if (throwable instanceof TransientDataAccessException
+            || throwable instanceof QueryTimeoutException
+            || throwable instanceof CannotAcquireLockException
+            || hasCause(throwable, SQLTransientException.class)) {
+            return FailureType.TRANSIENT;
+        }
+        // Unknown failures are retried first so operators can inspect exhausted messages in DLQ.
+        return FailureType.TRANSIENT;
+    }
+
+    private static boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedType) {
+        Throwable cursor = throwable;
+        while (cursor != null) {
+            if (expectedType.isInstance(cursor)) {
+                return true;
+            }
+            cursor = cursor.getCause();
+        }
+        return false;
+    }
+
+    public enum FailureType {
+        TRANSIENT,
+        PERMANENT
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationPersistenceService.java
@@ -45,7 +45,9 @@ public class NotificationPersistenceService {
         notification.setMessage(draft.message());
         notification.setDedupeKey(dedupeKey);
         Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("eventVersion", event.eventVersion());
         payload.put("eventId", event.eventId() != null ? event.eventId().toString() : null);
+        payload.put("correlationId", event.correlationId());
         payload.put("eventType", event.eventType() != null ? event.eventType().name() : null);
         payload.put("status", event.status() != null ? event.status().name() : null);
         // Store as ISO-8601 text to avoid runtime mapper module mismatch for java.time types.

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationTemplateService.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/NotificationTemplateService.java
@@ -6,6 +6,7 @@ import com.ubb.deliveryhub.notification.domain.NotificationType;
 import com.ubb.deliveryhub.notification.events.NotificationRequested;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -20,7 +21,7 @@ public class NotificationTemplateService {
     }
 
     private static NotificationDraft assignmentAccepted(NotificationRequested event, UUID recipientUserId) {
-        boolean actorIsRecipient = event.actorUserId().equals(recipientUserId);
+        boolean actorIsRecipient = Objects.equals(event.actorUserId(), recipientUserId);
         String title = actorIsRecipient ? "Delivery assignment confirmed" : "Courier assigned";
         String message = actorIsRecipient
             ? "You are now assigned to delivery %s.".formatted(shortDeliveryCode(event.deliveryId()))
@@ -52,6 +53,9 @@ public class NotificationTemplateService {
     }
 
     private static String shortDeliveryCode(UUID deliveryId) {
+        if (deliveryId == null) {
+            return "UNKNOWN";
+        }
         String raw = deliveryId.toString().replace("-", "");
         return "DH-" + raw.substring(0, Math.min(8, raw.length())).toUpperCase();
     }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/application/exception/PermanentNotificationMessageException.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/application/exception/PermanentNotificationMessageException.java
@@ -1,0 +1,20 @@
+package com.ubb.deliveryhub.notification.application.exception;
+
+public class PermanentNotificationMessageException extends RuntimeException {
+
+    private final String reason;
+
+    public PermanentNotificationMessageException(String reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    public PermanentNotificationMessageException(String reason, String message, Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    public String reason() {
+        return reason;
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
@@ -1,15 +1,22 @@
 package com.ubb.deliveryhub.notification.config;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@Validated
 @ConfigurationProperties(prefix = "notifications")
 public class NotificationProperties {
 
+    @Valid
     private final Async async = new Async();
 
     public Async getAsync() {
@@ -21,18 +28,30 @@ public class NotificationProperties {
         private boolean enabled = false;
         private boolean consumerEnabled = false;
         private boolean fallbackToSync = true;
+        @Min(0)
         private int maxRetries = 5;
+        @Min(1)
         private int maxTargetUserIds = 100;
+        @Min(256)
         private int maxMetadataBytes = 8192;
+        @NotBlank
         private String exchange = "notification.events";
+        @NotBlank
         private String routingKey = "notification.requested";
+        @NotBlank
         private String queue = "notification.consume.q";
+        @NotBlank
         private String retryQueue = "notification.consume.retry.q";
+        @NotBlank
         private String retryRoutingKey = "notification.requested.retry";
+        @NotBlank
         private String dlx = "notification.consume.dlx";
+        @NotBlank
         private String dlq = "notification.consume.dlq";
+        @NotBlank
         private String dlqRoutingKey = "notification.requested.dlq";
-        private List<Long> retryBackoffMillis = new ArrayList<>(List.of(1000L, 3000L, 10000L, 30000L, 60000L));
+        @NotEmpty
+        private List<@Min(1) Long> retryBackoffMillis = new ArrayList<>(List.of(1000L, 3000L, 10000L, 30000L, 60000L));
 
         public boolean isEnabled() {
             return enabled;
@@ -63,7 +82,7 @@ public class NotificationProperties {
         }
 
         public void setMaxRetries(int maxRetries) {
-            this.maxRetries = Math.max(0, maxRetries);
+            this.maxRetries = maxRetries;
         }
 
         public int getMaxTargetUserIds() {
@@ -71,7 +90,7 @@ public class NotificationProperties {
         }
 
         public void setMaxTargetUserIds(int maxTargetUserIds) {
-            this.maxTargetUserIds = Math.max(1, maxTargetUserIds);
+            this.maxTargetUserIds = maxTargetUserIds;
         }
 
         public int getMaxMetadataBytes() {
@@ -79,7 +98,7 @@ public class NotificationProperties {
         }
 
         public void setMaxMetadataBytes(int maxMetadataBytes) {
-            this.maxMetadataBytes = Math.max(256, maxMetadataBytes);
+            this.maxMetadataBytes = maxMetadataBytes;
         }
 
         public String getExchange() {
@@ -146,15 +165,11 @@ public class NotificationProperties {
             this.dlqRoutingKey = dlqRoutingKey;
         }
 
-        public List<Long> getRetryBackoffMillis() {
+        public List<@Min(1) Long> getRetryBackoffMillis() {
             return retryBackoffMillis;
         }
 
-        public void setRetryBackoffMillis(List<Long> retryBackoffMillis) {
-            if (retryBackoffMillis == null || retryBackoffMillis.isEmpty()) {
-                this.retryBackoffMillis = new ArrayList<>(List.of(1000L));
-                return;
-            }
+        public void setRetryBackoffMillis(List<@Min(1) Long> retryBackoffMillis) {
             this.retryBackoffMillis = new ArrayList<>(retryBackoffMillis);
         }
     }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/config/NotificationProperties.java
@@ -3,6 +3,9 @@ package com.ubb.deliveryhub.notification.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Component
 @ConfigurationProperties(prefix = "notifications")
 public class NotificationProperties {
@@ -16,9 +19,20 @@ public class NotificationProperties {
     public static class Async {
 
         private boolean enabled = false;
+        private boolean consumerEnabled = false;
         private boolean fallbackToSync = true;
-        private String exchange = "deliveryhub.notifications";
-        private String routingKey = "requested";
+        private int maxRetries = 5;
+        private int maxTargetUserIds = 100;
+        private int maxMetadataBytes = 8192;
+        private String exchange = "notification.events";
+        private String routingKey = "notification.requested";
+        private String queue = "notification.consume.q";
+        private String retryQueue = "notification.consume.retry.q";
+        private String retryRoutingKey = "notification.requested.retry";
+        private String dlx = "notification.consume.dlx";
+        private String dlq = "notification.consume.dlq";
+        private String dlqRoutingKey = "notification.requested.dlq";
+        private List<Long> retryBackoffMillis = new ArrayList<>(List.of(1000L, 3000L, 10000L, 30000L, 60000L));
 
         public boolean isEnabled() {
             return enabled;
@@ -28,12 +42,44 @@ public class NotificationProperties {
             this.enabled = enabled;
         }
 
+        public boolean isConsumerEnabled() {
+            return consumerEnabled;
+        }
+
+        public void setConsumerEnabled(boolean consumerEnabled) {
+            this.consumerEnabled = consumerEnabled;
+        }
+
         public boolean isFallbackToSync() {
             return fallbackToSync;
         }
 
         public void setFallbackToSync(boolean fallbackToSync) {
             this.fallbackToSync = fallbackToSync;
+        }
+
+        public int getMaxRetries() {
+            return maxRetries;
+        }
+
+        public void setMaxRetries(int maxRetries) {
+            this.maxRetries = Math.max(0, maxRetries);
+        }
+
+        public int getMaxTargetUserIds() {
+            return maxTargetUserIds;
+        }
+
+        public void setMaxTargetUserIds(int maxTargetUserIds) {
+            this.maxTargetUserIds = Math.max(1, maxTargetUserIds);
+        }
+
+        public int getMaxMetadataBytes() {
+            return maxMetadataBytes;
+        }
+
+        public void setMaxMetadataBytes(int maxMetadataBytes) {
+            this.maxMetadataBytes = Math.max(256, maxMetadataBytes);
         }
 
         public String getExchange() {
@@ -50,6 +96,66 @@ public class NotificationProperties {
 
         public void setRoutingKey(String routingKey) {
             this.routingKey = routingKey;
+        }
+
+        public String getQueue() {
+            return queue;
+        }
+
+        public void setQueue(String queue) {
+            this.queue = queue;
+        }
+
+        public String getRetryQueue() {
+            return retryQueue;
+        }
+
+        public void setRetryQueue(String retryQueue) {
+            this.retryQueue = retryQueue;
+        }
+
+        public String getRetryRoutingKey() {
+            return retryRoutingKey;
+        }
+
+        public void setRetryRoutingKey(String retryRoutingKey) {
+            this.retryRoutingKey = retryRoutingKey;
+        }
+
+        public String getDlx() {
+            return dlx;
+        }
+
+        public void setDlx(String dlx) {
+            this.dlx = dlx;
+        }
+
+        public String getDlq() {
+            return dlq;
+        }
+
+        public void setDlq(String dlq) {
+            this.dlq = dlq;
+        }
+
+        public String getDlqRoutingKey() {
+            return dlqRoutingKey;
+        }
+
+        public void setDlqRoutingKey(String dlqRoutingKey) {
+            this.dlqRoutingKey = dlqRoutingKey;
+        }
+
+        public List<Long> getRetryBackoffMillis() {
+            return retryBackoffMillis;
+        }
+
+        public void setRetryBackoffMillis(List<Long> retryBackoffMillis) {
+            if (retryBackoffMillis == null || retryBackoffMillis.isEmpty()) {
+                this.retryBackoffMillis = new ArrayList<>(List.of(1000L));
+                return;
+            }
+            this.retryBackoffMillis = new ArrayList<>(retryBackoffMillis);
         }
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationRequested.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/events/NotificationRequested.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import java.util.UUID;
 
 public record NotificationRequested(
+    Integer eventVersion,
     UUID eventId,
+    String correlationId,
     NotificationEventType eventType,
     UUID deliveryId,
     UUID actorUserId,

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
@@ -1,11 +1,14 @@
 package com.ubb.deliveryhub.notification.infrastructure.rabbit;
 
 import com.ubb.deliveryhub.notification.config.NotificationProperties;
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -20,6 +23,17 @@ public class NotificationRabbitConfig {
     @Bean
     public MessageConverter notificationMessageConverter() {
         return new JacksonJsonMessageConverter();
+    }
+
+    @Bean(name = "manualAckNotificationRabbitListenerContainerFactory")
+    public SimpleRabbitListenerContainerFactory manualAckNotificationRabbitListenerContainerFactory(
+        ConnectionFactory connectionFactory
+    ) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+        factory.setDefaultRequeueRejected(false);
+        return factory;
     }
 
     @Bean

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRabbitConfig.java
@@ -1,9 +1,18 @@
 package com.ubb.deliveryhub.notification.infrastructure.rabbit;
 
+import com.ubb.deliveryhub.notification.config.NotificationProperties;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 @Configuration
 public class NotificationRabbitConfig {
@@ -11,5 +20,75 @@ public class NotificationRabbitConfig {
     @Bean
     public MessageConverter notificationMessageConverter() {
         return new JacksonJsonMessageConverter();
+    }
+
+    @Bean
+    public TopicExchange notificationEventsExchange(NotificationProperties properties) {
+        return new TopicExchange(properties.getAsync().getExchange(), true, false);
+    }
+
+    @Bean
+    public DirectExchange notificationDlqExchange(NotificationProperties properties) {
+        return new DirectExchange(properties.getAsync().getDlx(), true, false);
+    }
+
+    @Bean
+    public Queue notificationConsumeQueue(NotificationProperties properties) {
+        return new Queue(properties.getAsync().getQueue(), true);
+    }
+
+    @Bean
+    public Queue notificationConsumeRetryQueue(NotificationProperties properties) {
+        return new Queue(
+            properties.getAsync().getRetryQueue(),
+            true,
+            false,
+            false,
+            Map.of(
+                "x-dead-letter-exchange", properties.getAsync().getExchange(),
+                "x-dead-letter-routing-key", properties.getAsync().getRoutingKey()
+            )
+        );
+    }
+
+    @Bean
+    public Queue notificationConsumeDlq(NotificationProperties properties) {
+        return new Queue(properties.getAsync().getDlq(), true);
+    }
+
+    @Bean
+    public Binding notificationConsumeBinding(
+        @Qualifier("notificationConsumeQueue") Queue notificationConsumeQueue,
+        TopicExchange notificationEventsExchange,
+        NotificationProperties properties
+    ) {
+        return BindingBuilder
+            .bind(notificationConsumeQueue)
+            .to(notificationEventsExchange)
+            .with(properties.getAsync().getRoutingKey());
+    }
+
+    @Bean
+    public Binding notificationConsumeRetryBinding(
+        @Qualifier("notificationConsumeRetryQueue") Queue notificationConsumeRetryQueue,
+        TopicExchange notificationEventsExchange,
+        NotificationProperties properties
+    ) {
+        return BindingBuilder
+            .bind(notificationConsumeRetryQueue)
+            .to(notificationEventsExchange)
+            .with(properties.getAsync().getRetryRoutingKey());
+    }
+
+    @Bean
+    public Binding notificationConsumeDlqBinding(
+        @Qualifier("notificationConsumeDlq") Queue notificationConsumeDlq,
+        DirectExchange notificationDlqExchange,
+        NotificationProperties properties
+    ) {
+        return BindingBuilder
+            .bind(notificationConsumeDlq)
+            .to(notificationDlqExchange)
+            .with(properties.getAsync().getDlqRoutingKey());
     }
 }

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRequestedConsumer.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRequestedConsumer.java
@@ -1,0 +1,322 @@
+package com.ubb.deliveryhub.notification.infrastructure.rabbit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import com.ubb.deliveryhub.notification.application.NotificationAsyncMetrics;
+import com.ubb.deliveryhub.notification.application.NotificationAsyncProcessor;
+import com.ubb.deliveryhub.notification.application.NotificationMessageFailureClassifier;
+import com.ubb.deliveryhub.notification.application.exception.PermanentNotificationMessageException;
+import com.ubb.deliveryhub.notification.config.NotificationProperties;
+import com.ubb.deliveryhub.notification.events.NotificationRequested;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.core.MessagePropertiesBuilder;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class NotificationRequestedConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationRequestedConsumer.class);
+
+    private final ObjectMapper objectMapper;
+    private final NotificationAsyncProcessor processor;
+    private final NotificationMessageFailureClassifier failureClassifier;
+    private final NotificationAsyncMetrics metrics;
+    private final RabbitTemplate rabbitTemplate;
+    private final NotificationProperties properties;
+
+    public NotificationRequestedConsumer(
+        ObjectMapper objectMapper,
+        NotificationAsyncProcessor processor,
+        NotificationMessageFailureClassifier failureClassifier,
+        NotificationAsyncMetrics metrics,
+        RabbitTemplate rabbitTemplate,
+        NotificationProperties properties
+    ) {
+        this.objectMapper = objectMapper;
+        this.processor = processor;
+        this.failureClassifier = failureClassifier;
+        this.metrics = metrics;
+        this.rabbitTemplate = rabbitTemplate;
+        this.properties = properties;
+    }
+
+    @RabbitListener(
+        queues = "${notifications.async.queue:notification.consume.q}",
+        containerFactory = "manualAckRabbitListenerContainerFactory",
+        autoStartup = "${notifications.async.consumer-enabled:false}"
+    )
+    public void consume(Message rawMessage, Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag)
+        throws IOException {
+        Instant startedAt = Instant.now();
+        int attempt = readRetryCount(rawMessage);
+        NotificationRequested message = null;
+        try {
+            message = decodeAndValidate(rawMessage);
+            String correlationId = resolveCorrelationId(message, rawMessage);
+            String previousCorrelationId = MDC.get("correlationId");
+            try {
+                if (correlationId != null && !correlationId.isBlank()) {
+                    MDC.put("correlationId", correlationId);
+                }
+                processMessage(channel, deliveryTag, attempt, message, startedAt);
+            } finally {
+                restoreCorrelation(previousCorrelationId);
+            }
+        } catch (Exception ex) {
+            try {
+                handleFailure(rawMessage, channel, deliveryTag, message, attempt, ex, startedAt);
+            } catch (Exception failureHandlingEx) {
+                log.error(
+                    "Failure while handling NotificationRequested error path; requeueing original message deliveryTag={}",
+                    deliveryTag,
+                    failureHandlingEx
+                );
+                channel.basicNack(deliveryTag, false, true);
+            }
+        }
+    }
+
+    private void processMessage(
+        Channel channel,
+        long deliveryTag,
+        int attempt,
+        NotificationRequested message,
+        Instant startedAt
+    ) throws IOException {
+        NotificationAsyncProcessor.Outcome outcome = processor.process(message);
+        channel.basicAck(deliveryTag, false);
+        String metricOutcome = outcome == NotificationAsyncProcessor.Outcome.DUPLICATE ? "duplicate" : "success";
+        metrics.recordConsume(metricOutcome, Duration.between(startedAt, Instant.now()));
+        log.info(
+            "NotificationRequested consumed eventId={} correlationId={} eventType={} targetCount={} attempt={} outcome={}",
+            message.eventId(),
+            message.correlationId(),
+            message.eventType(),
+            message.targetUserIds().size(),
+            attempt,
+            metricOutcome
+        );
+    }
+
+    private void handleFailure(
+        Message rawMessage,
+        Channel channel,
+        long deliveryTag,
+        NotificationRequested message,
+        int attempt,
+        Exception ex,
+        Instant startedAt
+    ) throws IOException {
+        NotificationMessageFailureClassifier.FailureType failureType = failureClassifier.classify(ex);
+        String eventId = message == null || message.eventId() == null ? "unknown" : message.eventId().toString();
+        String correlationId = resolveCorrelationId(message, rawMessage);
+        if (failureType == NotificationMessageFailureClassifier.FailureType.PERMANENT) {
+            publishToDlq(rawMessage, attempt, ex, "permanent_failure", correlationId);
+            channel.basicAck(deliveryTag, false);
+            metrics.recordConsume("dlq", Duration.between(startedAt, Instant.now()));
+            log.warn(
+                "NotificationRequested routed to DLQ eventId={} correlationId={} attempt={} reason={}",
+                eventId,
+                correlationId,
+                attempt,
+                extractFailureReason(ex)
+            );
+            return;
+        }
+
+        int nextAttempt = attempt + 1;
+        if (nextAttempt > properties.getAsync().getMaxRetries()) {
+            publishToDlq(rawMessage, attempt, ex, "retry_exhausted", correlationId);
+            channel.basicAck(deliveryTag, false);
+            metrics.recordConsume("dlq", Duration.between(startedAt, Instant.now()));
+            log.warn(
+                "NotificationRequested retry exhausted, moved to DLQ eventId={} correlationId={} attempts={}",
+                eventId,
+                correlationId,
+                attempt
+            );
+            return;
+        }
+
+        publishToRetry(rawMessage, nextAttempt, ex, correlationId);
+        channel.basicAck(deliveryTag, false);
+        metrics.recordConsume("retry", Duration.between(startedAt, Instant.now()));
+        log.warn(
+            "NotificationRequested scheduled for retry eventId={} correlationId={} attempt={} maxRetries={} reason={}",
+            eventId,
+            correlationId,
+            nextAttempt,
+            properties.getAsync().getMaxRetries(),
+            extractFailureReason(ex)
+        );
+    }
+
+    private NotificationRequested decodeAndValidate(Message rawMessage) {
+        try {
+            NotificationRequested message = objectMapper.readValue(rawMessage.getBody(), NotificationRequested.class);
+            if (message.eventVersion() == null || message.eventVersion() != 1) {
+                throw new PermanentNotificationMessageException(
+                    "UNSUPPORTED_EVENT_VERSION",
+                    "Unsupported eventVersion " + message.eventVersion()
+                );
+            }
+            if (message.eventId() == null) {
+                throw new PermanentNotificationMessageException("MISSING_EVENT_ID", "eventId is required");
+            }
+            if (message.eventType() == null) {
+                throw new PermanentNotificationMessageException("MISSING_EVENT_TYPE", "eventType is required");
+            }
+            if (message.occurredAt() == null) {
+                throw new PermanentNotificationMessageException("MISSING_OCCURRED_AT", "occurredAt is required");
+            }
+            if (message.targetUserIds() == null || message.targetUserIds().isEmpty()) {
+                throw new PermanentNotificationMessageException("MISSING_TARGET_USERS", "targetUserIds must not be empty");
+            }
+            if (message.targetUserIds().size() > properties.getAsync().getMaxTargetUserIds()) {
+                throw new PermanentNotificationMessageException(
+                    "TARGET_USER_LIMIT_EXCEEDED",
+                    "targetUserIds size exceeds configured limit"
+                );
+            }
+            for (UUID targetUserId : message.targetUserIds()) {
+                if (targetUserId == null) {
+                    throw new PermanentNotificationMessageException(
+                        "INVALID_TARGET_USER",
+                        "targetUserIds must not contain null values"
+                    );
+                }
+            }
+            if (message.metadata() != null) {
+                int metadataBytes = objectMapper.writeValueAsBytes(message.metadata()).length;
+                if (metadataBytes > properties.getAsync().getMaxMetadataBytes()) {
+                    throw new PermanentNotificationMessageException(
+                        "METADATA_TOO_LARGE",
+                        "metadata exceeds configured byte limit"
+                    );
+                }
+            }
+            return message;
+        } catch (PermanentNotificationMessageException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new PermanentNotificationMessageException(
+                "INVALID_PAYLOAD",
+                "Failed to decode NotificationRequested payload",
+                ex
+            );
+        }
+    }
+
+    private void publishToRetry(Message original, int nextAttempt, Exception ex, String correlationId) {
+        long delayMillis = resolveBackoffMillis(nextAttempt);
+        MessageProperties propertiesCopy = MessagePropertiesBuilder
+            .fromClonedProperties(original.getMessageProperties())
+            .build();
+        Message retryMessage = MessageBuilder
+            .withBody(original.getBody())
+            .andProperties(propertiesCopy)
+            .setHeader("x-retry-count", nextAttempt)
+            .setHeader("x-attempt-count", nextAttempt)
+            .setHeader("x-last-failure-reason", extractFailureReason(ex))
+            .setHeader("x-last-exception-class", ex.getClass().getName())
+            .setHeaderIfAbsent("x-first-failure-at", Instant.now().toString())
+            .setHeaderIfAbsent("x-correlation-id", correlationId)
+            .setExpiration(Long.toString(delayMillis))
+            .build();
+        rabbitTemplate.send(properties.getAsync().getExchange(), properties.getAsync().getRetryRoutingKey(), retryMessage);
+    }
+
+    private void publishToDlq(
+        Message original,
+        int retryCount,
+        Exception ex,
+        String failureReason,
+        String correlationId
+    ) {
+        Map<String, Object> headers = new LinkedHashMap<>(original.getMessageProperties().getHeaders());
+        headers.put("x-failure-reason", failureReason + ":" + extractFailureReason(ex));
+        headers.put("x-exception-class", ex.getClass().getName());
+        headers.put("x-attempt-count", retryCount);
+        headers.put("x-original-exchange", original.getMessageProperties().getReceivedExchange());
+        headers.put("x-original-routing-key", original.getMessageProperties().getReceivedRoutingKey());
+        headers.put("x-correlation-id", correlationId);
+        headers.putIfAbsent("x-first-failure-at", Instant.now().toString());
+        headers.put("x-last-failure-at", Instant.now().toString());
+
+        MessageProperties propertiesCopy = MessagePropertiesBuilder
+            .fromClonedProperties(original.getMessageProperties())
+            .build();
+        Message dlqMessage = MessageBuilder
+            .withBody(original.getBody())
+            .andProperties(propertiesCopy)
+            .copyHeaders(headers)
+            .build();
+        rabbitTemplate.send(properties.getAsync().getDlx(), properties.getAsync().getDlqRoutingKey(), dlqMessage);
+        metrics.recordDlqPublish();
+    }
+
+    private static int readRetryCount(Message rawMessage) {
+        Object value = rawMessage.getMessageProperties().getHeaders().get("x-retry-count");
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String stringValue) {
+            try {
+                return Integer.parseInt(stringValue);
+            } catch (NumberFormatException ignored) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    private long resolveBackoffMillis(int nextAttempt) {
+        if (properties.getAsync().getRetryBackoffMillis().isEmpty()) {
+            return 1000L;
+        }
+        int index = Math.max(0, Math.min(nextAttempt - 1, properties.getAsync().getRetryBackoffMillis().size() - 1));
+        return properties.getAsync().getRetryBackoffMillis().get(index);
+    }
+
+    private static String extractFailureReason(Exception ex) {
+        if (ex instanceof PermanentNotificationMessageException permanent && permanent.reason() != null) {
+            return permanent.reason();
+        }
+        return ex.getClass().getSimpleName();
+    }
+
+    private static String resolveCorrelationId(NotificationRequested message, Message rawMessage) {
+        if (message != null && message.correlationId() != null && !message.correlationId().isBlank()) {
+            return message.correlationId();
+        }
+        Object value = rawMessage.getMessageProperties().getHeaders().get("x-correlation-id");
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return stringValue;
+        }
+        return null;
+    }
+
+    private static void restoreCorrelation(String previousCorrelationId) {
+        if (previousCorrelationId == null || previousCorrelationId.isBlank()) {
+            MDC.remove("correlationId");
+            return;
+        }
+        MDC.put("correlationId", previousCorrelationId);
+    }
+}

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRequestedConsumer.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/infrastructure/rabbit/NotificationRequestedConsumer.java
@@ -58,7 +58,7 @@ public class NotificationRequestedConsumer {
 
     @RabbitListener(
         queues = "${notifications.async.queue:notification.consume.q}",
-        containerFactory = "manualAckRabbitListenerContainerFactory",
+        containerFactory = "manualAckNotificationRabbitListenerContainerFactory",
         autoStartup = "${notifications.async.consumer-enabled:false}"
     )
     public void consume(Message rawMessage, Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag)
@@ -170,7 +170,10 @@ public class NotificationRequestedConsumer {
     private NotificationRequested decodeAndValidate(Message rawMessage) {
         try {
             NotificationRequested message = objectMapper.readValue(rawMessage.getBody(), NotificationRequested.class);
-            if (message.eventVersion() == null || message.eventVersion() != 1) {
+            if (message.eventVersion() == null) {
+                throw new PermanentNotificationMessageException("MISSING_EVENT_VERSION", "eventVersion is required");
+            }
+            if (message.eventVersion() != 1) {
                 throw new PermanentNotificationMessageException(
                     "UNSUPPORTED_EVENT_VERSION",
                     "Unsupported eventVersion " + message.eventVersion()

--- a/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
+++ b/backend/src/main/java/com/ubb/deliveryhub/notification/listener/NotificationRequestedListener.java
@@ -109,10 +109,9 @@ public class NotificationRequestedListener {
     }
 
     private static String dedupeKey(NotificationRequested event, UUID recipientUserId) {
-        String statusToken = event.status() == null ? "NA" : event.status().name();
-        String deliveryToken = Objects.toString(event.deliveryId(), "NA");
-        return ("%s:%s:%s:%s")
-            .formatted(recipientUserId, deliveryToken, event.eventType(), statusToken)
+        String eventToken = Objects.toString(event.eventId(), "NA");
+        return ("%s:%s")
+            .formatted(eventToken, recipientUserId)
             .toLowerCase(Locale.ROOT);
     }
 }

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -13,6 +13,8 @@ spring.rabbitmq.virtual-host=${SPRING_RABBITMQ_VIRTUAL_HOST:/}
 # Keep local notification flow persisted for #48 UI consumption.
 notifications.async.enabled=${NOTIFICATIONS_ASYNC_ENABLED:false}
 notifications.async.fallback-to-sync=${NOTIFICATIONS_ASYNC_FALLBACK_TO_SYNC:true}
+notifications.async.consumer-enabled=${NOTIFICATIONS_ASYNC_CONSUMER_ENABLED:false}
+notifications.async.max-retries=${NOTIFICATIONS_ASYNC_MAX_RETRIES:5}
 
 # async assignment defaults stay off in local unless explicitly enabled
 delivery.assignment.async.enabled=${DELIVERY_ASSIGNMENT_ASYNC_ENABLED:false}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,8 +26,19 @@ jwt.expiration=86400000
 # notifications emission toggle (default sync write)
 notifications.async.enabled=true
 notifications.async.fallback-to-sync=true
-notifications.async.exchange=deliveryhub.notifications
-notifications.async.routing-key=requested
+notifications.async.consumer-enabled=false
+notifications.async.max-retries=5
+notifications.async.max-target-user-ids=100
+notifications.async.max-metadata-bytes=8192
+notifications.async.exchange=notification.events
+notifications.async.routing-key=notification.requested
+notifications.async.queue=notification.consume.q
+notifications.async.retry-queue=notification.consume.retry.q
+notifications.async.retry-routing-key=notification.requested.retry
+notifications.async.dlx=notification.consume.dlx
+notifications.async.dlq=notification.consume.dlq
+notifications.async.dlq-routing-key=notification.requested.dlq
+notifications.async.retry-backoff-millis=1000,3000,10000,30000,60000
 
 # async delivery assignment via RabbitMQ (task #68)
 delivery.assignment.async.enabled=false


### PR DESCRIPTION
This pull request introduces a robust asynchronous notification consumer with Dead Letter Queue (DLQ) support, improved error classification, and enhanced operational guidance for message replay. It also adds new metrics, configuration options, and event fields to support traceability and resilience in notification processing.

**Key changes:**

### Async Notification Consumer & DLQ Handling

- Added an async notification consumer with manual-acknowledgment, explicit transient/permanent error classification, and DLQ routing for failed messages. Exhausted messages include diagnostic headers for operational analysis, and a runbook is provided for safe inspection and replay of DLQ messages.
- Introduced `NotificationMessageFailureClassifier` to distinguish between transient and permanent failures, ensuring only retryable errors are retried and others go directly to DLQ. 

### Notification Event & Processing Enhancements

- Extended `NotificationRequested` event with `eventVersion` and `correlationId` fields for better traceability and versioned processing. 
- Updated notification persistence to store new event fields in the payload for downstream analysis. 
- Improved template rendering to handle null actor/recipient IDs and delivery IDs robustly. 

### Metrics & Observability

- Added `NotificationAsyncMetrics` to track consumption outcomes, DLQ publishing, and processing durations using Micrometer, supporting better monitoring and alerting. 

### Configuration Improvements

- Expanded `NotificationProperties.Async` with new options for consumer enablement, retry policies, queue/exchange names, DLQ configuration, and batch sizes. These changes support more flexible and safer async notification processing. 

---

These changes collectively make the notification system more resilient, observable, and operator-friendly, especially in the face of message failures and operational replay scenarios.