### PR TITLE
User Profile Page

### DIFF
--- a/backend/common/src/main/java/com/ubb/deliveryhub/common/web/CommonExceptionHandler.java
+++ b/backend/common/src/main/java/com/ubb/deliveryhub/common/web/CommonExceptionHandler.java
@@ -35,6 +35,15 @@ public class CommonExceptionHandler {
             .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Malformed request body"));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalArgument(IllegalArgumentException ex) {
+        String detail = ex.getMessage() != null && !ex.getMessage().isBlank()
+            ? ex.getMessage()
+            : "Invalid request parameter";
+        return ResponseEntity.badRequest()
+            .body(ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail));
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ProblemDetail> handleNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/domain/dto/UpdateUserProfileRequest.java
+++ b/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/domain/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,31 @@
+package com.ubb.deliveryhub.identity.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class UpdateUserProfileRequest {
+
+    @NotNull
+    @Valid
+    @JsonAlias("personalInfo")
+    private PersonalDto personal;
+
+    @Data
+    public static class PersonalDto {
+
+        @NotBlank
+        @Size(max = 255)
+        private String displayName;
+
+        @NotBlank
+        @Size(max = 40)
+        @Pattern(regexp = "^[+0-9()\\-.\\s]{7,40}$")
+        private String phone;
+    }
+}

--- a/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/service/UserService.java
+++ b/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/service/UserService.java
@@ -1,11 +1,14 @@
 package com.ubb.deliveryhub.identity.service;
 
 import com.ubb.deliveryhub.common.domain.User;
+import com.ubb.deliveryhub.identity.domain.dto.UpdateUserProfileRequest;
 import com.ubb.deliveryhub.identity.domain.dto.UserDto;
 import com.ubb.deliveryhub.common.exception.EntityNotFoundException;
 import com.ubb.deliveryhub.common.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -19,9 +22,36 @@ public class UserService {
         return UserDto.fromUser(getById(id));
     }
 
+    @Transactional(readOnly = true)
+    public UserDto getCurrentUser(Authentication authentication) {
+        return UserDto.fromUser(getById(principalUserId(authentication)));
+    }
+
+    @Transactional
+    public UserDto updateCurrentUserProfile(
+        Authentication authentication,
+        UpdateUserProfileRequest request
+    ) {
+        User user = getById(principalUserId(authentication));
+
+        UpdateUserProfileRequest.PersonalDto personal = request.getPersonal();
+        user.setDisplayName(personal.getDisplayName().trim());
+        user.setPhoneNumber(personal.getPhone().trim());
+
+        return UserDto.fromUser(repository.save(user));
+    }
+
     private User getById(String id) {
-        return this.repository.findById(UUID.fromString(id))
+        return getById(UUID.fromString(id));
+    }
+
+    private User getById(UUID id) {
+        return this.repository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException("User with id %s not found".formatted(id)));
+    }
+
+    private static UUID principalUserId(Authentication authentication) {
+        return UUID.fromString(authentication.getName());
     }
 
 }

--- a/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/service/UserService.java
+++ b/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/service/UserService.java
@@ -42,7 +42,7 @@ public class UserService {
     }
 
     private User getById(String id) {
-        return getById(UUID.fromString(id));
+        return getById(parseUserId(id));
     }
 
     private User getById(UUID id) {
@@ -50,8 +50,16 @@ public class UserService {
             .orElseThrow(() -> new EntityNotFoundException("User with id %s not found".formatted(id)));
     }
 
+    private static UUID parseUserId(String id) {
+        try {
+            return UUID.fromString(id);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Invalid user id format");
+        }
+    }
+
     private static UUID principalUserId(Authentication authentication) {
-        return UUID.fromString(authentication.getName());
+        return parseUserId(authentication.getName());
     }
 
 }

--- a/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/web/UserController.java
+++ b/backend/identity-service/src/main/java/com/ubb/deliveryhub/identity/web/UserController.java
@@ -1,10 +1,19 @@
 package com.ubb.deliveryhub.identity.web;
 
+import com.ubb.deliveryhub.identity.domain.dto.UpdateUserProfileRequest;
 import com.ubb.deliveryhub.identity.domain.dto.UserDto;
 import com.ubb.deliveryhub.identity.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,6 +21,21 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService service;
+
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<UserDto> getCurrentUser(Authentication authentication) {
+        return ResponseEntity.ok(service.getCurrentUser(authentication));
+    }
+
+    @PutMapping("/me")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<UserDto> updateCurrentUserProfile(
+        Authentication authentication,
+        @Valid @RequestBody UpdateUserProfileRequest request
+    ) {
+        return ResponseEntity.ok(service.updateCurrentUserProfile(authentication, request));
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<UserDto> getUserById(@PathVariable String id) {

--- a/frontend/src/app/core/navigation/app-nav.config.ts
+++ b/frontend/src/app/core/navigation/app-nav.config.ts
@@ -115,7 +115,7 @@ export const APP_NAV_SECTIONS: readonly NavSection[] = [
         roles: [UserRole.CUSTOMER],
       },
       {
-        label: 'Profile',
+        label: 'Profile & Settings',
         routerCommands: ['customer', 'profile'],
         icon: 'pi pi-id-card',
         roles: [UserRole.CUSTOMER],

--- a/frontend/src/app/features/customer/customer.routes.ts
+++ b/frontend/src/app/features/customer/customer.routes.ts
@@ -1,10 +1,5 @@
 import { Routes } from '@angular/router';
 
-const loadStub = () =>
-  import('@shared/pages/portal-route-stub/portal-route-stub').then(
-    (m) => m.PortalRouteStub,
-  );
-
 export const customerRoutes: Routes = [
   {
     path: '',
@@ -84,7 +79,13 @@ export const customerRoutes: Routes = [
   },
   {
     path: 'profile',
-    loadComponent: loadStub,
-    data: { pageTitle: 'Profile' },
+    loadComponent: () =>
+      import('./pages/customer-profile/customer-profile').then(
+        (m) => m.CustomerProfilePage,
+      ),
+    data: {
+      pageTitle: 'Profile & Settings',
+      subtitle: 'Manage your account and preferences',
+    },
   },
 ];

--- a/frontend/src/app/features/customer/models/customer-profile.models.ts
+++ b/frontend/src/app/features/customer/models/customer-profile.models.ts
@@ -1,0 +1,16 @@
+export interface CustomerProfilePersonalDto {
+  displayName: string;
+  phone: string;
+  email: string;
+}
+
+export interface CustomerProfileDto {
+  personal: CustomerProfilePersonalDto;
+}
+
+export interface CustomerProfileUpdateRequest {
+  personal: {
+    displayName: string;
+    phone: string;
+  };
+}

--- a/frontend/src/app/features/customer/pages/customer-profile/customer-profile.html
+++ b/frontend/src/app/features/customer/pages/customer-profile/customer-profile.html
@@ -1,0 +1,127 @@
+<div class="flex min-h-0 flex-1 flex-col bg-p-surface-ground">
+  <div class="mx-auto w-full max-w-[1040px] space-y-4 p-5">
+    @if (loading() && !hasLoadedAtLeastOnce()) {
+      <div class="grid gap-4">
+        <p-card>
+          <div class="space-y-2">
+            <p-skeleton width="10rem" height="1rem" />
+            <p-skeleton width="100%" height="2.2rem" />
+            <p-skeleton width="100%" height="2.2rem" />
+            <p-skeleton width="100%" height="2.2rem" />
+          </div>
+        </p-card>
+      </div>
+    } @else if (loadError(); as errorState) {
+      <p-card>
+        <div class="flex flex-col gap-3">
+          <h2 class="text-lg font-semibold text-p-text-primary">{{ errorState.title }}</h2>
+          <p class="text-sm text-p-text-muted">{{ errorState.message }}</p>
+          <div class="pt-1">
+            <p-button label="Retry" icon="pi pi-refresh" (onClick)="retryLoad()" />
+          </div>
+        </div>
+      </p-card>
+    } @else {
+      <form [formGroup]="form" (ngSubmit)="saveProfile()" class="space-y-4">
+        <p-card>
+          <div class="space-y-4" formGroupName="personal">
+            <div class="flex items-center gap-2">
+              <span
+                class="inline-flex h-8 w-8 items-center justify-center rounded-(--p-radius-md) bg-blue-50 text-blue-600"
+              >
+                <i class="pi pi-user text-sm" aria-hidden="true"></i>
+              </span>
+              <div>
+                <h2 class="text-base font-semibold text-p-text-primary">Personal Information</h2>
+                <p class="text-xs text-p-text-muted">
+                  Used for delivery updates and courier contact.
+                </p>
+              </div>
+            </div>
+
+            <div class="grid gap-3 border-t border-p-surface-border pt-3 md:grid-cols-2">
+              <div>
+                <label
+                  class="mb-1 block text-xs font-semibold tracking-wide text-p-text-muted uppercase"
+                  for="customer-displayName"
+                >
+                  Display name
+                </label>
+                <input
+                  id="customer-displayName"
+                  pInputText
+                  class="w-full"
+                  [class.ng-invalid]="isFieldInvalid('personal.displayName')"
+                  formControlName="displayName"
+                  placeholder="Enter your name"
+                />
+                @if (fieldError('personal.displayName'); as error) {
+                  <small class="mt-1 block text-xs text-red-600">{{ error }}</small>
+                }
+              </div>
+
+              <div>
+                <label
+                  class="mb-1 block text-xs font-semibold tracking-wide text-p-text-muted uppercase"
+                  for="customer-phone"
+                >
+                  Phone
+                </label>
+                <input
+                  id="customer-phone"
+                  pInputText
+                  class="w-full"
+                  [class.ng-invalid]="isFieldInvalid('personal.phone')"
+                  formControlName="phone"
+                  placeholder="+40..."
+                />
+                @if (fieldError('personal.phone'); as error) {
+                  <small class="mt-1 block text-xs text-red-600">{{ error }}</small>
+                }
+              </div>
+
+              <div class="md:col-span-2">
+                <label
+                  class="mb-1 block text-xs font-semibold tracking-wide text-p-text-muted uppercase"
+                  for="customer-email"
+                >
+                  Email
+                </label>
+                <input
+                  id="customer-email"
+                  pInputText
+                  class="w-full bg-p-surface-ground text-p-text-muted"
+                  formControlName="email"
+                  readonly
+                />
+                <p class="mt-1 text-xs text-p-text-muted">
+                  Email is managed by your account administrator and cannot be changed here.
+                </p>
+              </div>
+            </div>
+          </div>
+        </p-card>
+
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          @if (hasUnsavedChanges) {
+            <span class="text-xs text-amber-600">You have unsaved changes.</span>
+          }
+          <p-button
+            type="button"
+            label="Cancel"
+            severity="secondary"
+            [outlined]="true"
+            [disabled]="saving() || !hasUnsavedChanges"
+            (onClick)="cancelChanges()"
+          />
+          <p-button
+            type="submit"
+            label="Save profile"
+            [loading]="saving()"
+            [disabled]="saving() || !hasUnsavedChanges"
+          />
+        </div>
+      </form>
+    }
+  </div>
+</div>

--- a/frontend/src/app/features/customer/pages/customer-profile/customer-profile.ts
+++ b/frontend/src/app/features/customer/pages/customer-profile/customer-profile.ts
@@ -1,0 +1,304 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AbstractControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { UserService } from '@core/services/user/user';
+import { MessageService } from 'primeng/api';
+import { Button } from 'primeng/button';
+import { Card } from 'primeng/card';
+import { InputText } from 'primeng/inputtext';
+import { Skeleton } from 'primeng/skeleton';
+import { finalize } from 'rxjs';
+import {
+  CustomerProfileDto,
+  CustomerProfileUpdateRequest,
+} from '../../models/customer-profile.models';
+import { CustomerProfileService } from '../../services/customer-profile.service';
+
+interface CustomerProfileLoadErrorState {
+  title: string;
+  message: string;
+}
+
+@Component({
+  selector: 'app-customer-profile-page',
+  imports: [
+    ReactiveFormsModule,
+    Card,
+    Button,
+    InputText,
+    Skeleton,
+  ],
+  templateUrl: './customer-profile.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomerProfilePage {
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly customerProfileService = inject(CustomerProfileService);
+  private readonly messageService = inject(MessageService);
+  private readonly userService = inject(UserService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly loading = signal(true);
+  protected readonly hasLoadedAtLeastOnce = signal(false);
+  protected readonly saving = signal(false);
+  protected readonly submitAttempted = signal(false);
+  protected readonly loadError = signal<CustomerProfileLoadErrorState | null>(null);
+
+  private lastLoadedSnapshot: CustomerProfileDto | null = null;
+  private lastLoadedComparable: CustomerProfileUpdateRequest | null = null;
+
+  protected readonly form = this.fb.group({
+    personal: this.fb.group({
+      displayName: this.fb.control('', {
+        validators: [Validators.required, Validators.maxLength(120)],
+      }),
+      phone: this.fb.control('', {
+        validators: [
+          Validators.required,
+          Validators.maxLength(40),
+          Validators.pattern(/^[+0-9()\-.\s]{7,40}$/),
+        ],
+      }),
+      email: this.fb.control({ value: '', disabled: true }),
+    }),
+  });
+
+  constructor() {
+    this.loadProfile();
+  }
+
+  protected retryLoad(): void {
+    this.loadProfile();
+  }
+
+  protected saveProfile(): void {
+    if (this.saving()) {
+      return;
+    }
+    if (!this.hasUnsavedChanges) {
+      return;
+    }
+
+    this.submitAttempted.set(true);
+    this.clearServerErrors(this.form);
+    this.form.updateValueAndValidity();
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.saving.set(true);
+    this.customerProfileService
+      .updateMyProfile(this.buildPayload())
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.saving.set(false)),
+      )
+      .subscribe({
+        next: () => {
+          this.userService
+            .refreshCurrentUser()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe();
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Profile updated',
+            detail: 'Your account information was saved successfully.',
+            life: 4000,
+          });
+          this.loadProfile();
+        },
+        error: (error: unknown) => {
+          if (
+            error instanceof HttpErrorResponse &&
+            this.customerProfileService.applyValidationErrors(this.form, error)
+          ) {
+            this.form.markAllAsTouched();
+            return;
+          }
+
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Could not save profile',
+            detail: 'Please review your data and try again.',
+            life: 5000,
+          });
+        },
+      });
+  }
+
+  protected cancelChanges(): void {
+    if (!this.lastLoadedSnapshot) {
+      return;
+    }
+    this.applyProfileToForm(this.lastLoadedSnapshot);
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Changes discarded',
+      detail: 'Profile fields were reset to the last saved values.',
+      life: 3500,
+    });
+  }
+
+  protected isFieldInvalid(controlPath: string): boolean {
+    const control = this.form.get(controlPath);
+    if (!control) {
+      return false;
+    }
+
+    return control.invalid && (control.touched || this.submitAttempted());
+  }
+
+  protected fieldError(controlPath: string): string | null {
+    const control = this.form.get(controlPath);
+    if (!control || !(control.touched || this.submitAttempted()) || !control.errors) {
+      return null;
+    }
+
+    if (control.errors['server']) {
+      return String(control.errors['server']);
+    }
+    if (control.errors['required']) {
+      return 'This field is required.';
+    }
+    if (control.errors['maxlength']) {
+      return `Maximum length is ${control.errors['maxlength'].requiredLength} characters.`;
+    }
+    if (control.errors['pattern']) {
+      return 'Value format is invalid.';
+    }
+
+    return 'Invalid value.';
+  }
+
+  protected get hasUnsavedChanges(): boolean {
+    if (!this.lastLoadedComparable) {
+      return false;
+    }
+    return !this.isSameAsLoadedSnapshot();
+  }
+
+  private loadProfile(): void {
+    this.loading.set(true);
+    this.loadError.set(null);
+
+    this.customerProfileService
+      .getMyProfile()
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.loading.set(false)),
+      )
+      .subscribe({
+        next: (profile) => {
+          this.lastLoadedSnapshot = profile;
+          this.applyProfileToForm(profile);
+          this.hasLoadedAtLeastOnce.set(true);
+        },
+        error: (error: unknown) => {
+          this.hasLoadedAtLeastOnce.set(true);
+          this.loadError.set(this.toLoadErrorState(error));
+        },
+      });
+  }
+
+  private applyProfileToForm(profile: CustomerProfileDto): void {
+    this.submitAttempted.set(false);
+    this.clearServerErrors(this.form);
+    this.lastLoadedComparable = this.toComparablePayloadFromProfile(profile);
+
+    this.form.patchValue(
+      {
+        personal: {
+          displayName: profile.personal.displayName,
+          phone: profile.personal.phone,
+          email: profile.personal.email,
+        },
+      },
+      { emitEvent: false },
+    );
+
+    this.form.markAsPristine();
+    this.form.markAsUntouched();
+    this.form.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private buildPayload(): CustomerProfileUpdateRequest {
+    const raw = this.form.getRawValue();
+
+    return {
+      personal: {
+        displayName: raw.personal.displayName.trim(),
+        phone: raw.personal.phone.trim(),
+      },
+    };
+  }
+
+  private isSameAsLoadedSnapshot(): boolean {
+    if (!this.lastLoadedComparable) {
+      return false;
+    }
+    const current = this.buildPayload();
+    return JSON.stringify(current) === JSON.stringify(this.lastLoadedComparable);
+  }
+
+  private toComparablePayloadFromProfile(
+    profile: CustomerProfileDto,
+  ): CustomerProfileUpdateRequest {
+    return {
+      personal: {
+        displayName: profile.personal.displayName.trim(),
+        phone: profile.personal.phone.trim(),
+      },
+    };
+  }
+
+  private clearServerErrors(control: AbstractControl): void {
+    if (control instanceof FormGroup) {
+      for (const child of Object.values(control.controls)) {
+        this.clearServerErrors(child);
+      }
+    }
+
+    if (!control.errors || !('server' in control.errors)) {
+      return;
+    }
+
+    const { server: _server, ...rest } = control.errors;
+    control.setErrors(Object.keys(rest).length > 0 ? rest : null);
+  }
+
+  private toLoadErrorState(error: unknown): CustomerProfileLoadErrorState {
+    if (error instanceof HttpErrorResponse && error.status === 404) {
+      return {
+        title: 'Profile not found',
+        message: 'Your account profile could not be loaded. Contact support if this persists.',
+      };
+    }
+
+    if (error instanceof HttpErrorResponse && error.status === 403) {
+      return {
+        title: 'Access denied',
+        message: 'Your account cannot access profile settings.',
+      };
+    }
+
+    return {
+      title: 'Could not load profile',
+      message: 'Please refresh or try again in a few moments.',
+    };
+  }
+}

--- a/frontend/src/app/features/customer/services/customer-profile.service.ts
+++ b/frontend/src/app/features/customer/services/customer-profile.service.ts
@@ -1,0 +1,177 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { BaseService } from '@core/services/base.service';
+import { map } from 'rxjs';
+import {
+  CustomerProfileDto,
+  CustomerProfileUpdateRequest,
+} from '../models/customer-profile.models';
+
+type CustomerProfileApiResponse = Partial<CustomerProfileDto> & {
+  displayName?: unknown;
+  fullName?: unknown;
+  name?: unknown;
+  phone?: unknown;
+  phoneNumber?: unknown;
+  email?: unknown;
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CustomerProfileService extends BaseService {
+  getMyProfile() {
+    return this.httpClient
+      .get<CustomerProfileApiResponse>(`${this.baseUrl}/users/me`)
+      .pipe(map((response) => this.normalizeProfileResponse(response)));
+  }
+
+  updateMyProfile(payload: CustomerProfileUpdateRequest) {
+    return this.httpClient
+      .put<CustomerProfileApiResponse>(`${this.baseUrl}/users/me`, payload)
+      .pipe(map((response) => this.normalizeProfileResponse(response)));
+  }
+
+  applyValidationErrors(form: FormGroup, error: HttpErrorResponse): boolean {
+    if (error.status !== 400 || !error.error) {
+      return false;
+    }
+
+    const fieldErrors = this.extractFieldErrors(error.error);
+    if (fieldErrors.length === 0) {
+      return false;
+    }
+
+    let applied = false;
+    for (const [rawField, message] of fieldErrors) {
+      const controlPath = this.normalizeControlPath(rawField);
+      const control = form.get(controlPath);
+      if (!control) {
+        continue;
+      }
+      control.setErrors({
+        ...(control.errors ?? {}),
+        server: message,
+      });
+      control.markAsTouched();
+      applied = true;
+    }
+
+    return applied;
+  }
+
+  private normalizeProfileResponse(
+    response: CustomerProfileApiResponse,
+  ): CustomerProfileDto {
+    const personalSource = this.asObject(response.personal);
+
+    return {
+      personal: {
+        displayName: this.toText(
+          personalSource?.['displayName'] ??
+            personalSource?.['fullName'] ??
+            personalSource?.['name'] ??
+            response.displayName ??
+            response.fullName ??
+            response.name,
+        ),
+        phone: this.toText(
+          personalSource?.['phone'] ??
+            personalSource?.['phoneNumber'] ??
+            response.phone ??
+            response.phoneNumber,
+        ),
+        email: this.toText(
+          personalSource?.['email'] ?? response.email,
+        ),
+      },
+    } satisfies CustomerProfileDto;
+  }
+
+  private extractFieldErrors(errorBody: unknown): Array<[string, string]> {
+    if (typeof errorBody !== 'object' || errorBody === null) {
+      return [];
+    }
+
+    const candidates: Array<[string, string]> = [];
+    const body = errorBody as {
+      errors?: Record<string, unknown>;
+      fieldErrors?: Record<string, unknown>;
+      violations?: unknown[];
+    };
+
+    this.appendErrorsFromMap(candidates, body.errors);
+    this.appendErrorsFromMap(candidates, body.fieldErrors);
+
+    if (Array.isArray(body.violations)) {
+      for (const violation of body.violations) {
+        if (!violation || typeof violation !== 'object') {
+          continue;
+        }
+        const item = violation as { field?: unknown; message?: unknown };
+        if (
+          typeof item.field === 'string' &&
+          item.field.length > 0 &&
+          typeof item.message === 'string' &&
+          item.message.length > 0
+        ) {
+          candidates.push([item.field, item.message]);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  private appendErrorsFromMap(
+    target: Array<[string, string]>,
+    source: Record<string, unknown> | undefined,
+  ): void {
+    if (!source || typeof source !== 'object') {
+      return;
+    }
+
+    for (const [field, value] of Object.entries(source)) {
+      if (Array.isArray(value) && value.length > 0) {
+        target.push([field, String(value[0])]);
+        continue;
+      }
+      if (typeof value === 'string' && value.length > 0) {
+        target.push([field, value]);
+      }
+    }
+  }
+
+  private normalizeControlPath(serverField: string): string {
+    const normalized = serverField.replaceAll('[', '.').replaceAll(']', '');
+    const aliases: Array<[RegExp, string]> = [
+      [/^(name|fullName)$/, 'personal.displayName'],
+      [/^(phone|phoneNumber)$/, 'personal.phone'],
+      [/^personalInfo\./, 'personal.'],
+      [/^personal\.displayName$/, 'personal.displayName'],
+      [/^personal\.phone$/, 'personal.phone'],
+    ];
+
+    for (const [pattern, target] of aliases) {
+      if (pattern.test(normalized)) {
+        return normalized.replace(pattern, target);
+      }
+    }
+
+    return normalized;
+  }
+
+  private asObject(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object'
+      ? (value as Record<string, unknown>)
+      : null;
+  }
+
+  private toText(value: unknown): string {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    return value.trim();
+  }
+}


### PR DESCRIPTION
This pull request implements the customer profile management feature, allowing customers to view and update their personal information (display name and phone number) in the application. It introduces backend endpoints and validation, updates the frontend navigation and routing, and adds a new profile page with form validation and API integration.

**Backend: Customer Profile Endpoints and Validation**
- Added `UpdateUserProfileRequest` DTO with validation for updating user profiles, including nested validation for personal info fields (`displayName`, `phone`).
- Implemented `getCurrentUser` and `updateCurrentUserProfile` methods in `UserService`, enabling authenticated users to fetch and update their own profile. Added helper methods for extracting user ID from authentication.
- Exposed new endpoints in `UserController` for `/users/me` (GET and PUT), restricted to users with the `CUSTOMER` role.

**Frontend: Navigation, Routing, and Models**
- Updated navigation label from "Profile" to "Profile & Settings" for clarity.
- Updated customer routes to load the new `CustomerProfilePage` for `/profile`, with page title and subtitle.
- Defined TypeScript models for customer profile data and update requests (`CustomerProfileDto`, `CustomerProfileUpdateRequest`).

**Frontend: Profile Page and Service**
- Added a new customer profile page with a form for editing display name and phone, showing email as read-only, and handling loading and error states. Includes unsaved changes detection and validation error display.
- Implemented `CustomerProfileService` to handle API calls for fetching and updating the profile, normalizing API responses, and applying server-side validation errors to the form.